### PR TITLE
Add Deeploans App MVP and GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/deploy-deeploans-app.yml
+++ b/.github/workflows/deploy-deeploans-app.yml
@@ -1,0 +1,46 @@
+name: Deploy Deeploans App (GitHub Pages)
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'deeploans-app/**'
+      - '.github/workflows/deploy-deeploans-app.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Prepare artifact
+        run: |
+          mkdir -p _site
+          cp -R deeploans-app/* _site/
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/deeploans-app/app.js
+++ b/deeploans-app/app.js
@@ -1,0 +1,101 @@
+const sampleData = [
+  { deal_id: 'DL-AUT-001', asset_class: 'aut', country: 'DE', originator: 'NorthBank', report_date: '2025-01-31', loan_count: 1200, balance_eur: 18200000 },
+  { deal_id: 'DL-SME-201', asset_class: 'sme', country: 'IT', originator: 'Atlas Credit', report_date: '2025-01-31', loan_count: 870, balance_eur: 25650000 },
+  { deal_id: 'DL-CMR-045', asset_class: 'cmr', country: 'FR', originator: 'RetailOne', report_date: '2025-01-31', loan_count: 2100, balance_eur: 14120000 },
+];
+
+const el = (id) => document.getElementById(id);
+
+function duplicateRate(rows) {
+  if (!rows.length) return 0;
+  const seen = new Set();
+  let dup = 0;
+  for (const row of rows) {
+    const key = JSON.stringify(row);
+    if (seen.has(key)) dup += 1;
+    seen.add(key);
+  }
+  return dup / rows.length;
+}
+
+function computeQuality(rows) {
+  if (!rows.length) return [];
+  const columns = Object.keys(rows[0]);
+  return columns.map((column) => {
+    const vals = rows.map((r) => r[column]);
+    const nulls = vals.filter((v) => v === null || v === undefined || v === '').length;
+    const distinct = new Set(vals.filter((v) => v !== null && v !== undefined && v !== '')).size;
+    return { column, null_rate: (nulls / rows.length).toFixed(3), distinct_count: distinct };
+  }).sort((a, b) => Number(b.null_rate) - Number(a.null_rate));
+}
+
+function renderTable(tableId, rows) {
+  const table = el(tableId);
+  table.innerHTML = '';
+  if (!rows.length) return;
+  const columns = Object.keys(rows[0]);
+  const thead = document.createElement('thead');
+  thead.innerHTML = `<tr>${columns.map((c) => `<th>${c}</th>`).join('')}</tr>`;
+  const tbody = document.createElement('tbody');
+  rows.forEach((row) => {
+    const tr = document.createElement('tr');
+    tr.innerHTML = columns.map((c) => `<td>${row[c] ?? ''}</td>`).join('');
+    tbody.appendChild(tr);
+  });
+  table.appendChild(thead);
+  table.appendChild(tbody);
+}
+
+function renderKpis(rows, source) {
+  el('kpis').innerHTML = `
+    <div class="kpi"><strong>Rows</strong><br/>${rows.length}</div>
+    <div class="kpi"><strong>Columns</strong><br/>${rows.length ? Object.keys(rows[0]).length : 0}</div>
+    <div class="kpi"><strong>Source</strong><br/>${source}</div>
+  `;
+}
+
+async function fetchData() {
+  const mode = el('sourceMode').value;
+  if (mode === 'sample') return { rows: sampleData, source: 'sample' };
+
+  const baseUrl = el('baseUrl').value.trim().replace(/\/$/, '');
+  const creditType = el('creditType').value;
+  const tableName = el('tableName').value.trim();
+  const limit = el('limit').value;
+  const offset = el('offset').value;
+  const filter = el('filterQuery').value.trim();
+  const apiKey = el('apiKey').value.trim();
+
+  const params = new URLSearchParams({ limit, offset });
+  if (filter) params.set('filter', filter);
+
+  const response = await fetch(`${baseUrl}/api/v1/${creditType}/${tableName}?${params.toString()}`, {
+    headers: apiKey ? { 'x-algoritmica-api-key': apiKey } : {},
+  });
+  if (!response.ok) throw new Error(`HTTP ${response.status}`);
+
+  const payload = await response.json();
+  const rows = Array.isArray(payload) ? payload : (payload.data || [payload]);
+  return { rows: Array.isArray(rows) ? rows : [], source: 'api' };
+}
+
+async function loadAndRender() {
+  try {
+    const { rows, source } = await fetchData();
+    renderKpis(rows, source);
+    renderTable('loanTable', rows);
+
+    const quality = computeQuality(rows);
+    renderTable('qualityTable', quality);
+    el('qualitySummary').textContent = `Duplicate rate: ${(duplicateRate(rows) * 100).toFixed(2)}%`;
+  } catch (err) {
+    renderKpis(sampleData, 'sample-fallback');
+    renderTable('loanTable', sampleData);
+    const quality = computeQuality(sampleData);
+    renderTable('qualityTable', quality);
+    el('qualitySummary').textContent = `API unavailable (${err.message}). Showing sample data.`;
+  }
+}
+
+el('loadBtn').addEventListener('click', loadAndRender);
+loadAndRender();

--- a/deeploans-app/index.html
+++ b/deeploans-app/index.html
@@ -1,0 +1,80 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Deeploans Explorer MVP</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header>
+      <h1>Deeploans Loan Tape Explorer + Data Quality Monitor</h1>
+      <p>MVP for ingestion status, tape exploration, quality checks, and API usage starter.</p>
+    </header>
+
+    <main>
+      <aside class="panel">
+        <h2>Connection</h2>
+        <label>Data source
+          <select id="sourceMode">
+            <option value="sample">Sample data</option>
+            <option value="api">API</option>
+          </select>
+        </label>
+        <label>Base API URL
+          <input id="baseUrl" value="http://localhost:8000" />
+        </label>
+        <label>API key (optional)
+          <input id="apiKey" type="password" placeholder="x-algoritmica-api-key" />
+        </label>
+        <label>Credit type
+          <select id="creditType">
+            <option>aut</option><option>cmr</option><option>cre</option>
+            <option>les</option><option>rmb</option><option>sme</option>
+          </select>
+        </label>
+        <label>Table
+          <input id="tableName" value="deals" />
+        </label>
+        <label>Limit
+          <input id="limit" type="number" value="500" min="1" max="10000" />
+        </label>
+        <label>Offset
+          <input id="offset" type="number" value="0" min="0" />
+        </label>
+        <label>Filter query
+          <input id="filterQuery" placeholder="e.g. country:DE" />
+        </label>
+        <button id="loadBtn">Load dataset</button>
+      </aside>
+
+      <section class="content">
+        <section class="panel">
+          <h2>1) Dataset Ingestion Status</h2>
+          <div id="kpis" class="kpis"></div>
+        </section>
+
+        <section class="panel">
+          <h2>2) Loan Tape Explorer</h2>
+          <div class="table-wrap"><table id="loanTable"></table></div>
+        </section>
+
+        <section class="panel">
+          <h2>3) Data Quality Dashboard</h2>
+          <div id="qualitySummary"></div>
+          <div class="table-wrap"><table id="qualityTable"></table></div>
+        </section>
+
+        <section class="panel">
+          <h2>4) API Usage Console (starter)</h2>
+          <p>
+            API key input is wired in this MVP. Next step: integrate admin endpoints
+            <code>/api/v1/dev/users</code> and <code>/api/v1/dev/user/&lt;id&gt;</code> for quota and user management.
+          </p>
+        </section>
+      </section>
+    </main>
+
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/deeploans-app/readme.md
+++ b/deeploans-app/readme.md
@@ -1,1 +1,41 @@
-This is the first commmit for the deeploans app
+# Deeploans App MVP
+
+A lightweight front-end MVP for:
+
+1. **Dataset Ingestion Status**
+2. **Loan Tape Explorer**
+3. **Data Quality Dashboard**
+4. **API Usage Console (starter)**
+
+## Is this runnable from GitHub?
+
+Yes — this app is now configured for **GitHub Pages** deployment via GitHub Actions.
+
+### First-time repository setup
+
+1. Push this branch to GitHub.
+2. In repository settings, go to **Pages**.
+3. Set source to **GitHub Actions**.
+4. Merge to `main` (or run the workflow manually).
+
+After deployment, the app will be available at:
+
+- `https://<org-or-user>.github.io/<repo>/`
+
+## Run locally
+
+```bash
+cd deeploans-app
+python -m http.server 4173
+```
+
+Open <http://localhost:4173>.
+
+## API mode
+
+Switch **Data source** to `API` and set:
+- Base API URL (default `http://localhost:8000`)
+- Optional `x-algoritmica-api-key`
+- Credit type + table + filters
+
+If API loading fails, the app automatically falls back to sample data.

--- a/deeploans-app/styles.css
+++ b/deeploans-app/styles.css
@@ -1,0 +1,15 @@
+:root { font-family: Inter, system-ui, sans-serif; }
+body { margin: 0; background: #f3f5f9; color: #111827; }
+header { padding: 1rem 1.5rem; background: #111827; color: #fff; }
+main { display: grid; grid-template-columns: 320px 1fr; gap: 1rem; padding: 1rem; }
+.panel { background: #fff; border-radius: 10px; padding: 1rem; box-shadow: 0 1px 4px rgba(0,0,0,.1); margin-bottom: 1rem; }
+label { display: block; margin-bottom: .6rem; font-size: .9rem; }
+input, select, button { width: 100%; padding: .45rem; margin-top: .2rem; box-sizing: border-box; }
+button { background: #2563eb; color: white; border: none; border-radius: 6px; cursor: pointer; }
+.kpis { display: flex; gap: .8rem; flex-wrap: wrap; }
+.kpi { background: #eef2ff; padding: .6rem .8rem; border-radius: 8px; }
+.table-wrap { overflow: auto; max-height: 360px; border: 1px solid #e5e7eb; }
+table { width: 100%; border-collapse: collapse; font-size: .85rem; }
+th, td { border-bottom: 1px solid #e5e7eb; padding: .4rem .5rem; text-align: left; }
+th { position: sticky; top: 0; background: #f9fafb; }
+@media (max-width: 980px) { main { grid-template-columns: 1fr; } }


### PR DESCRIPTION
### Motivation
- Provide a minimal front-end MVP for exploring loan tapes, monitoring simple data quality KPIs, and exercising the API usage console.  
- Enable easy hosting via GitHub Pages so the app can be published from the repository with GitHub Actions.  
- Offer a sample-data fallback so the UI remains usable when the API is unavailable.

### Description
- Add a lightweight single-page app under `deeploans-app` including `index.html`, `app.js`, `styles.css`, and `readme.md` that implements dataset KPIs, a loan table explorer, and a data-quality table from `computeQuality` and `duplicateRate`.  
- Implement client-side data loading with `fetchData()` that supports `sample` mode and an `API` mode which calls `GET /api/v1/<creditType>/<table>?limit=...&offset=...` and uses an optional `x-algoritmica-api-key` header.  
- Render KPIs (`renderKpis`), tables (`renderTable`), and quality metrics and provide graceful fallback to `sampleData` on errors.  
- Add a GitHub Actions workflow `/.github/workflows/deploy-deeploans-app.yml` to build and deploy the `_site` artifact to GitHub Pages using the Pages actions.

### Testing
- No automated tests were executed as part of this change (deployment workflow added but no CI test suites are included).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b8645f66ac8328ac1a395e2d010369)