### PR TITLE
Add standalone Deeploans MCP server exposing discovery and API-doc tools

### DIFF
--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -1,0 +1,43 @@
+# Deeploans MCP Server
+
+This folder contains a standalone MCP (Model Context Protocol) server for Deeploans.
+
+## What it provides
+
+The server currently exposes these tools:
+
+- `list_platform_components`: high-level map of Deeploans components
+- `get_asset_classes`: currently supported ETL asset classes
+- `fetch_api_docs`: fetches OpenAPI metadata from a running backend API
+
+## Quick start
+
+```bash
+cd mcp-server
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .
+```
+
+Run the server over stdio:
+
+```bash
+deeploans-mcp
+```
+
+## Example MCP client config
+
+```json
+{
+  "mcpServers": {
+    "deeploans": {
+      "command": "deeploans-mcp"
+    }
+  }
+}
+```
+
+## Notes
+
+- `fetch_api_docs` expects the API to be running (default: `http://localhost:8000`).
+- This service is intentionally separate from the FastAPI backend so it can evolve independently.

--- a/mcp-server/deeploans_mcp/__init__.py
+++ b/mcp-server/deeploans_mcp/__init__.py
@@ -1,0 +1,1 @@
+"""Deeploans MCP server package."""

--- a/mcp-server/deeploans_mcp/server.py
+++ b/mcp-server/deeploans_mcp/server.py
@@ -1,0 +1,92 @@
+"""Deeploans MCP server.
+
+This server exposes a small set of tools to help AI clients discover Deeploans
+components and inspect API health/documentation endpoints.
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+from typing import Any
+
+from mcp.server.fastmcp import FastMCP
+
+mcp = FastMCP("deeploans")
+
+
+@mcp.tool()
+def list_platform_components() -> dict[str, Any]:
+    """Return a high-level view of Deeploans components and repository layout."""
+    return {
+        "project": "deeploans",
+        "components": [
+            {
+                "name": "ETL-Pipelines",
+                "purpose": "Data processing and lakehouse pipelines",
+                "path": "ETL-Pipelines/",
+            },
+            {
+                "name": "api-backend",
+                "purpose": "FastAPI backend for querying datasets",
+                "path": "api/api-backend-main/backend/",
+            },
+            {
+                "name": "data-quality-app",
+                "purpose": "Frontend utility app for data quality checks",
+                "path": "deeploans-app-library/data-quality-app/",
+            },
+        ],
+    }
+
+
+@mcp.tool()
+def get_asset_classes() -> list[str]:
+    """Return the asset classes currently covered by Deeploans ETLs."""
+    return [
+        "SME loans",
+        "Residential mortgages",
+        "Consumer lending",
+        "Auto loans",
+    ]
+
+
+@mcp.tool()
+def fetch_api_docs(base_url: str = "http://localhost:8000") -> dict[str, Any]:
+    """Fetch the backend OpenAPI JSON from a running Deeploans API instance.
+
+    Args:
+        base_url: Base URL for the backend API service.
+
+    Returns:
+        Dictionary with status and OpenAPI metadata.
+    """
+    openapi_url = f"{base_url.rstrip('/')}/openapi.json"
+    request = urllib.request.Request(openapi_url, method="GET")
+
+    try:
+        with urllib.request.urlopen(request, timeout=5) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+            return {
+                "ok": True,
+                "url": openapi_url,
+                "title": payload.get("info", {}).get("title"),
+                "version": payload.get("info", {}).get("version"),
+                "paths_count": len(payload.get("paths", {})),
+            }
+    except urllib.error.URLError as exc:
+        return {
+            "ok": False,
+            "url": openapi_url,
+            "error": str(exc),
+        }
+
+
+def main() -> None:
+    """Run the MCP server over stdio."""
+    mcp.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/mcp-server/pyproject.toml
+++ b/mcp-server/pyproject.toml
@@ -1,0 +1,20 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "deeploans-mcp-server"
+version = "0.1.0"
+description = "MCP server for Deeploans data platform"
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = [
+  "mcp>=1.2.0"
+]
+
+[project.scripts]
+deeploans-mcp = "deeploans_mcp.server:main"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["deeploans_mcp*"]

--- a/readme.md
+++ b/readme.md
@@ -18,6 +18,12 @@ Deeploans has released ETLs for the following structured finance datasets:
 - Consumer Loans
 - Residential Mortgages
 
+Additional components in this repository include:
+
+- `api/api-backend-main/`: FastAPI backend for data access
+- `deeploans-app-library/data-quality-app/`: data quality frontend utility
+- `mcp-server/`: standalone MCP server for AI/client integrations
+
 <p align="center">
 <img src="deeploans_overview.png" alt="Deeploans Overview" title="deeploans overview" width="400">
 </p>


### PR DESCRIPTION
### Motivation
- Provide a lightweight MCP (Model Context Protocol) server to let AI clients discover Deeploans components and inspect backend API documentation and health.
- Offer a small surface of utility tools (component listing, asset classes, and OpenAPI fetch) that can evolve independently of the FastAPI backend.
- Make the MCP service easily runnable via a console entrypoint for local development and integrations.

### Description
- Add a new `mcp-server` package with `deeploans_mcp.server` implementing a `FastMCP` instance and three tools: `list_platform_components`, `get_asset_classes`, and `fetch_api_docs`.
- Add `pyproject.toml` to package and publish the console script entrypoint `deeploans-mcp` for running the server over stdio.
- Add `mcp-server/README.md` documenting usage and example client config, and update the top-level `readme.md` to mention the new `mcp-server` component.

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b8775bad58832891fb4e6188e04869)