### PR TITLE
Add Hastructure Studio frontend to build Hastructure payloads from Deeploans tape

### DIFF
--- a/app-library/hastructure-studio/app.js
+++ b/app-library/hastructure-studio/app.js
@@ -1,0 +1,254 @@
+const sampleTape = [
+  { loan_id: 'AUT-0001', current_balance: 24000, rate: 0.053, remaining_term_months: 48, ltv: 0.78 },
+  { loan_id: 'AUT-0002', current_balance: 18000, rate: 0.049, remaining_term_months: 40, ltv: 0.72 },
+  { loan_id: 'AUT-0003', current_balance: 31500, rate: 0.061, remaining_term_months: 56, ltv: 0.85 },
+  { loan_id: 'AUT-0004', current_balance: 12750, rate: 0.046, remaining_term_months: 27, ltv: 0.68 },
+  { loan_id: 'AUT-0005', current_balance: 22500, rate: 0.058, remaining_term_months: 51, ltv: 0.81 },
+];
+
+const el = (id) => document.getElementById(id);
+let activeTape = [...sampleTape];
+
+function money(v) {
+  return new Intl.NumberFormat('en-GB', { maximumFractionDigits: 0 }).format(v);
+}
+
+function pct(v, digits = 2) {
+  return `${(v * 100).toFixed(digits)}%`;
+}
+
+function pickNumber(row, candidates, fallback = 0) {
+  for (const key of candidates) {
+    if (row[key] !== undefined && row[key] !== null && row[key] !== '') {
+      const n = Number(row[key]);
+      if (!Number.isNaN(n)) return n;
+    }
+  }
+  return fallback;
+}
+
+function deriveAssumptionsFromTape(rows) {
+  if (!rows.length) return null;
+
+  const balances = rows.map((r) => pickNumber(r, ['current_balance', 'balance_eur', 'balance', 'outstanding_balance'], 0));
+  const totalBalance = balances.reduce((sum, b) => sum + b, 0);
+  if (!totalBalance) return null;
+
+  const weightedCoupon = rows.reduce((sum, r, i) => {
+    const raw = pickNumber(r, ['rate', 'coupon', 'interest_rate'], 0.05);
+    const coupon = raw > 1 ? raw / 100 : raw;
+    return sum + (balances[i] * coupon);
+  }, 0) / totalBalance;
+
+  const weightedTerm = rows.reduce((sum, r, i) => {
+    const term = pickNumber(r, ['remaining_term_months', 'remaining_term', 'term_months', 'term'], 48);
+    return sum + (balances[i] * term);
+  }, 0) / totalBalance;
+
+  const avgLtv = rows.reduce((sum, r) => {
+    const raw = pickNumber(r, ['ltv', 'current_ltv', 'loan_to_value'], 0.75);
+    return sum + (raw > 1 ? raw / 100 : raw);
+  }, 0) / rows.length;
+
+  const cdr = Math.min(0.05, Math.max(0.01, 0.01 + Math.max(0, avgLtv - 0.7) * 0.06));
+  const cpr = Math.min(0.16, Math.max(0.03, 0.05 + (weightedCoupon - 0.03) * 0.5));
+  const severity = Math.min(0.6, Math.max(0.2, 0.25 + Math.max(0, avgLtv - 0.65) * 0.55));
+
+  return {
+    poolBalance: Math.round(totalBalance),
+    coupon: weightedCoupon,
+    termMonths: Math.max(6, Math.round(weightedTerm)),
+    cdr,
+    cpr,
+    severity,
+    rows: rows.length,
+    avgLtv,
+  };
+}
+
+function applyAssumptionsToInputs(a) {
+  if (!a) return;
+  el('poolBalance').value = String(a.poolBalance);
+  el('coupon').value = (a.coupon * 100).toFixed(2);
+  el('termMonths').value = String(a.termMonths);
+  el('cpr').value = (a.cpr * 100).toFixed(2);
+  el('cdr').value = (a.cdr * 100).toFixed(2);
+  el('severity').value = (a.severity * 100).toFixed(2);
+
+  el('tapeSummary').innerHTML = `
+    <div class="kpi"><strong>Tape Rows</strong><br/>${a.rows}</div>
+    <div class="kpi"><strong>Pool Balance</strong><br/>€ ${money(a.poolBalance)}</div>
+    <div class="kpi"><strong>WAC</strong><br/>${pct(a.coupon)}</div>
+    <div class="kpi"><strong>WARM</strong><br/>${a.termMonths}m</div>
+    <div class="kpi"><strong>Avg LTV</strong><br/>${pct(a.avgLtv)}</div>
+  `;
+}
+
+function readInputs() {
+  return {
+    dealName: el('dealName').value.trim(),
+    poolBalance: Number(el('poolBalance').value),
+    coupon: Number(el('coupon').value) / 100,
+    termMonths: Number(el('termMonths').value),
+    cpr: Number(el('cpr').value) / 100,
+    cdr: Number(el('cdr').value) / 100,
+    severity: Number(el('severity').value) / 100,
+    seniorPct: Number(el('seniorPct').value) / 100,
+  };
+}
+
+function buildPayload(i) {
+  const seniorBalance = Math.round(i.poolBalance * i.seniorPct);
+  const juniorBalance = i.poolBalance - seniorBalance;
+
+  return {
+    metadata: {
+      source: 'deeploans',
+      tape_rows: activeTape.length,
+      created_at: new Date().toISOString(),
+    },
+    deal: {
+      name: i.dealName,
+      currency: 'EUR',
+      pool: {
+        balance: i.poolBalance,
+        assumptions: {
+          cpr: i.cpr,
+          cdr: i.cdr,
+          severity: i.severity,
+          coupon: i.coupon,
+          termMonths: i.termMonths,
+        },
+      },
+      liabilities: [
+        { class: 'A', type: 'senior', balance: seniorBalance, coupon: Math.max(0, i.coupon - 0.01) },
+        { class: 'B', type: 'junior', balance: juniorBalance, coupon: i.coupon + 0.02 },
+      ],
+      waterfall: ['fees', 'interest_A', 'principal_A', 'interest_B', 'principal_B', 'residual'],
+    },
+  };
+}
+
+function projectCashflows(i, months = 12) {
+  let bal = i.poolBalance;
+  const rows = [];
+  const schedPrin = i.poolBalance / i.termMonths;
+
+  for (let m = 1; m <= months; m += 1) {
+    const prepay = bal * i.cpr / 12;
+    const defaults = bal * i.cdr / 12;
+    const loss = defaults * i.severity;
+    const recoveries = defaults - loss;
+    const principal = Math.min(schedPrin + prepay + recoveries, bal);
+    const interest = bal * i.coupon / 12;
+    const startBalance = bal;
+    bal = Math.max(0, bal - principal - loss);
+
+    rows.push({ month: `M${m}`, start_balance: startBalance, interest, principal, loss, end_balance: bal });
+  }
+  return rows;
+}
+
+function renderKpis(rows) {
+  const totInt = rows.reduce((s, r) => s + r.interest, 0);
+  const totPrin = rows.reduce((s, r) => s + r.principal, 0);
+  const totLoss = rows.reduce((s, r) => s + r.loss, 0);
+  el('kpis').innerHTML = `
+    <div class="kpi"><strong>12m Interest</strong><br/>€ ${money(totInt)}</div>
+    <div class="kpi"><strong>12m Principal</strong><br/>€ ${money(totPrin)}</div>
+    <div class="kpi"><strong>12m Loss</strong><br/>€ ${money(totLoss)}</div>
+    <div class="kpi"><strong>12m End Balance</strong><br/>€ ${money(rows[rows.length - 1]?.end_balance || 0)}</div>
+  `;
+}
+
+function renderTable(rows) {
+  const table = el('cashflowTable');
+  const cols = Object.keys(rows[0] || {});
+  table.innerHTML = `<thead><tr>${cols.map((c) => `<th>${c}</th>`).join('')}</tr></thead>`;
+  const body = document.createElement('tbody');
+  rows.forEach((r) => {
+    const tr = document.createElement('tr');
+    tr.innerHTML = cols.map((c) => `<td>${typeof r[c] === 'number' ? money(r[c]) : r[c]}</td>`).join('');
+    body.appendChild(tr);
+  });
+  table.appendChild(body);
+}
+
+function buildAndRender() {
+  const inputs = readInputs();
+  const payload = buildPayload(inputs);
+  const rows = projectCashflows(inputs);
+  renderKpis(rows);
+  renderTable(rows);
+  el('payload').textContent = JSON.stringify(payload, null, 2);
+  return payload;
+}
+
+async function fetchTape() {
+  const mode = el('sourceMode').value;
+  if (mode === 'sample') {
+    el('sourceStatus').textContent = 'Using sample tape.';
+    return [...sampleTape];
+  }
+
+  const baseUrl = el('baseUrl').value.trim().replace(/\/$/, '');
+  const creditType = el('creditType').value;
+  const tableName = el('tableName').value.trim();
+  const limit = el('limit').value;
+  const offset = el('offset').value;
+  const filter = el('filterQuery').value.trim();
+  const apiKey = el('apiKey').value.trim();
+
+  const params = new URLSearchParams({ limit, offset });
+  if (filter) params.set('filter', filter);
+
+  const res = await fetch(`${baseUrl}/api/v1/${creditType}/${tableName}?${params.toString()}`, {
+    headers: apiKey ? { 'x-algoritmica-api-key': apiKey } : {},
+  });
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+
+  const payload = await res.json();
+  const rows = Array.isArray(payload) ? payload : (payload.data || [payload]);
+  return Array.isArray(rows) ? rows : [];
+}
+
+async function loadTapeAndDerive() {
+  try {
+    const tape = await fetchTape();
+    if (!tape.length) throw new Error('No rows returned');
+    activeTape = tape;
+    const assumptions = deriveAssumptionsFromTape(tape);
+    if (!assumptions) throw new Error('Could not derive assumptions from returned columns');
+    applyAssumptionsToInputs(assumptions);
+    el('sourceStatus').textContent = `Loaded ${tape.length} rows from ${el('sourceMode').value === 'api' ? 'Deeploans API' : 'sample tape'}.`;
+    buildAndRender();
+  } catch (err) {
+    activeTape = [...sampleTape];
+    const fallback = deriveAssumptionsFromTape(activeTape);
+    applyAssumptionsToInputs(fallback);
+    el('sourceStatus').textContent = `Data load failed (${err.message}). Fallback to sample tape.`;
+    buildAndRender();
+  }
+}
+
+async function runHastructure() {
+  const payload = buildAndRender();
+  const url = el('serviceUrl').value.trim();
+  try {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const out = await res.json();
+    el('response').textContent = JSON.stringify(out, null, 2);
+  } catch (err) {
+    el('response').textContent = `Could not reach Hastructure service (${err.message}).\n\nTip: start Hastructure locally and expose a POST endpoint, then update Service URL.`;
+  }
+}
+
+el('loadTapeBtn').addEventListener('click', loadTapeAndDerive);
+el('buildBtn').addEventListener('click', buildAndRender);
+el('runBtn').addEventListener('click', runHastructure);
+loadTapeAndDerive();

--- a/app-library/hastructure-studio/index.html
+++ b/app-library/hastructure-studio/index.html
@@ -1,0 +1,90 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Deeploans × Hastructure Studio</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header>
+      <h1>Deeploans × Hastructure Studio</h1>
+      <p>Use Deeploans loan-tape data to derive pool assumptions, then generate and run a Hastructure payload.</p>
+    </header>
+
+    <main>
+      <section class="panel">
+        <h2>1) Deeploans Data Source</h2>
+        <div class="grid source-grid">
+          <label>Data source
+            <select id="sourceMode">
+              <option value="sample">Sample loan tape</option>
+              <option value="api">Deeploans API</option>
+            </select>
+          </label>
+          <label>Base API URL <input id="baseUrl" value="http://localhost:8000" /></label>
+          <label>Credit type
+            <select id="creditType">
+              <option>aut</option><option>cmr</option><option>cre</option>
+              <option>les</option><option>rmb</option><option>sme</option>
+            </select>
+          </label>
+          <label>Table <input id="tableName" value="deals" /></label>
+          <label>Limit <input id="limit" type="number" value="300" min="1" max="10000" /></label>
+          <label>Offset <input id="offset" type="number" value="0" min="0" /></label>
+          <label>Filter query <input id="filterQuery" placeholder="e.g. country:DE" /></label>
+          <label>API key (optional)
+            <input id="apiKey" type="password" placeholder="x-algoritmica-api-key" />
+          </label>
+        </div>
+        <div class="actions">
+          <button id="loadTapeBtn">Load Deeploans Tape</button>
+          <span id="sourceStatus" class="status">Using sample tape.</span>
+        </div>
+      </section>
+
+      <section class="panel">
+        <h2>2) Deal Inputs (auto-filled from tape)</h2>
+        <div class="grid">
+          <label>Deal Name <input id="dealName" value="DL Demo Auto 2026-1" /></label>
+          <label>Pool Balance (€) <input id="poolBalance" type="number" value="25000000" min="1000" step="1000" /></label>
+          <label>Coupon (%) <input id="coupon" type="number" value="4.8" min="0" step="0.01" /></label>
+          <label>Term (months) <input id="termMonths" type="number" value="60" min="1" /></label>
+          <label>CPR (%) <input id="cpr" type="number" value="6" min="0" step="0.1" /></label>
+          <label>CDR (%) <input id="cdr" type="number" value="1.8" min="0" step="0.1" /></label>
+          <label>Severity (%) <input id="severity" type="number" value="35" min="0" max="100" step="0.1" /></label>
+          <label>Senior % <input id="seniorPct" type="number" value="82" min="1" max="99" step="0.1" /></label>
+        </div>
+
+        <h3>3) Hastructure Connection</h3>
+        <div class="grid two">
+          <label>Service URL <input id="serviceUrl" value="http://localhost:8081/runDeal" /></label>
+          <button id="runBtn">Run in Hastructure</button>
+        </div>
+
+        <div class="actions">
+          <button id="buildBtn">Build Payload</button>
+        </div>
+      </section>
+
+      <section class="panel">
+        <h2>4) Tape Summary + Preview Metrics</h2>
+        <div id="tapeSummary" class="kpis"></div>
+        <div id="kpis" class="kpis"></div>
+        <div class="table-wrap"><table id="cashflowTable"></table></div>
+      </section>
+
+      <section class="panel">
+        <h2>Generated Hastructure-style Payload</h2>
+        <pre id="payload"></pre>
+      </section>
+
+      <section class="panel">
+        <h2>Hastructure Response</h2>
+        <pre id="response">No run yet.</pre>
+      </section>
+    </main>
+
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/app-library/hastructure-studio/readme.md
+++ b/app-library/hastructure-studio/readme.md
@@ -1,0 +1,28 @@
+# Deeploans × Hastructure Studio
+
+This app is the bridge between **Deeploans** and **Hastructure**:
+
+1. Pull loan tape rows from Deeploans (sample or Deeploans API).
+2. Derive deal assumptions from tape-level fields (pool balance, WAC, WARM, proxy CPR/CDR/severity).
+3. Generate a Hastructure-style JSON payload.
+4. Optionally POST the payload to a running Hastructure service endpoint.
+
+## Run locally
+
+```bash
+cd app-library/hastructure-studio
+python -m http.server 4180
+```
+
+Open http://localhost:4180.
+
+## Deeploans connection
+
+- API mode calls: `GET /api/v1/{creditType}/{table}`
+- Returned loan-level rows are mapped into pool-level assumptions used in the payload builder.
+- If API is unavailable, the app falls back to sample Deeploans-style tape rows.
+
+## Notes
+
+- This utility does **not** bundle the Hastructure engine.
+- It acts as a Deeploans-informed payload builder and connector for users running Hastructure separately.

--- a/app-library/hastructure-studio/styles.css
+++ b/app-library/hastructure-studio/styles.css
@@ -1,0 +1,22 @@
+:root { font-family: Inter, system-ui, sans-serif; }
+body { margin: 0; background: #f4f7fb; color: #0f172a; }
+header { padding: 1rem 1.25rem; background: #0f172a; color: #e2e8f0; }
+main { padding: 1rem; display: grid; gap: 1rem; }
+.panel { background: #fff; border-radius: 10px; padding: 1rem; box-shadow: 0 1px 4px rgba(0,0,0,0.12); }
+.grid { display: grid; grid-template-columns: repeat(4, minmax(180px, 1fr)); gap: .6rem; }
+.source-grid { grid-template-columns: repeat(4, minmax(160px, 1fr)); }
+.grid.two { grid-template-columns: 1fr 200px; align-items: end; }
+label { display: flex; flex-direction: column; font-size: .9rem; gap: .2rem; }
+input, select, button { font: inherit; padding: .5rem; border: 1px solid #cbd5e1; border-radius: 6px; }
+button { background: #2563eb; color: #fff; cursor: pointer; border: none; }
+.actions { margin-top: .8rem; display: flex; align-items: center; gap: .7rem; }
+.status { color: #334155; font-size: .9rem; }
+.kpis { display: flex; gap: .75rem; flex-wrap: wrap; margin-bottom: .8rem; }
+.kpi { background: #e0e7ff; border-radius: 8px; padding: .55rem .7rem; }
+.table-wrap { max-height: 300px; overflow: auto; border: 1px solid #e2e8f0; }
+table { width: 100%; border-collapse: collapse; font-size: .86rem; }
+th, td { border-bottom: 1px solid #e2e8f0; padding: .35rem .5rem; text-align: right; }
+th:first-child, td:first-child { text-align: left; }
+pre { background: #020617; color: #dbeafe; padding: .8rem; border-radius: 8px; overflow: auto; max-height: 360px; }
+@media (max-width: 1100px) { .grid, .source-grid { grid-template-columns: repeat(2, minmax(180px, 1fr)); } }
+@media (max-width: 720px) { .grid, .source-grid, .grid.two { grid-template-columns: 1fr; } }

--- a/readme.md
+++ b/readme.md
@@ -21,7 +21,8 @@ Deeploans has released ETLs for the following structured finance datasets:
 Additional components in this repository include:
 
 - `api/api-backend-main/`: FastAPI backend for data access
-- `deeploans-app-library/data-quality-app/`: data quality frontend utility
+- `app-library/data-quality/`: data quality frontend utility
+- `app-library/hastructure-studio/`: frontend payload builder/connector for Hastructure scenario runs
 - `mcp-server/`: standalone MCP server for AI/client integrations
 
 <p align="center">


### PR DESCRIPTION
### Motivation
- Provide a lightweight browser-based utility to convert Deeploans loan-tape rows into Hastructure-style deal payloads and to optionally POST scenarios to a running Hastructure service. 
- Enable users to derive pool-level assumptions (WAC, WARM, CPR/CDR/severity) from loan-level data so payloads are grounded in tape characteristics. 
- Offer a simple UI that can load a sample tape or pull rows from the Deeploans API and fall back to sample data on failure. 

### Description
- Add a new app at `app-library/hastructure-studio/` with `index.html`, `app.js`, `styles.css`, and `readme.md` implementing the UI and logic to fetch tape rows, derive assumptions, build a Hastructure payload, simulate 12-month cashflows, and render KPIs and a cashflow table. 
- Implement `deriveAssumptionsFromTape` to compute weighted coupon, weighted term, average LTV, and heuristic `cpr`, `cdr`, and `severity` proxies from common loan-level fields. 
- Implement payload builder (`buildPayload`) and `projectCashflows` to create the Hastructure-style JSON and simulate amortisation/credit losses; include `runHastructure` to POST the payload to a configurable service URL. 
- Update the repository-level `readme.md` to reference the new `app-library/hastructure-studio/` app and include a local run instruction in the app readme. 

### Testing
- No automated tests were added or executed for these new frontend assets.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b87d8a0ae08328a7d2b403e68e213f)