### PR TITLE
Codex-generated pull request

### DIFF
--- a/etl-pipelines/exotic/data-centers/readme.md
+++ b/etl-pipelines/exotic/data-centers/readme.md
@@ -2,7 +2,7 @@
 
 This folder contains an MVP ETL pipeline for **data-center-backed private debt deals**.
 
-It is structured with the same bronze/silver/gold logic used in Deeploans:
+It follows the same medallion architecture patterns used by the other ETLs:
 
 - **Bronze**: raw records + ingestion metadata + basic numeric validation
 - **Silver**: normalized facility metrics (NOI, DSCR, LTV, occupancy, energy ratio) + covenant status
@@ -11,7 +11,8 @@ It is structured with the same bronze/silver/gold logic used in Deeploans:
 ## Folder layout
 
 - `sample_data/raw_facilities.csv`: sample raw facility-level input
-- `src/data_center_etl.py`: ETL script
+- `src/data_center_etl.py`: ETL entrypoint with stage-based execution
+- `src/data_center_etl_pipeline/`: stage modules (`generate_bronze_tables`, `generate_asset_silver`, `generate_gold_tables`)
 - `output/`: generated bronze/silver/gold outputs
 
 ## Run
@@ -24,5 +25,13 @@ make run
 Or directly:
 
 ```bash
-python src/data_center_etl.py --input sample_data/raw_facilities.csv --output output
+python src/data_center_etl.py --input sample_data/raw_facilities.csv --output output --stage-name all
+```
+
+To execute an individual stage:
+
+```bash
+python src/data_center_etl.py --input sample_data/raw_facilities.csv --output output --stage-name bronze
+python src/data_center_etl.py --input sample_data/raw_facilities.csv --output output --stage-name silver
+python src/data_center_etl.py --input sample_data/raw_facilities.csv --output output --stage-name gold
 ```

--- a/etl-pipelines/exotic/data-centers/src/data_center_etl.py
+++ b/etl-pipelines/exotic/data-centers/src/data_center_etl.py
@@ -1,218 +1,66 @@
 #!/usr/bin/env python3
-"""Minimal ETL pipeline for exotic data-center-backed private debt deals."""
+"""Data-center ETL runner using bronze/silver/gold medallion stages."""
 
 from __future__ import annotations
 
 import argparse
-import csv
-import hashlib
 import os
-from dataclasses import dataclass
-from datetime import datetime, timezone
-from typing import Dict, Iterable, List
 
-NUMERIC_FIELDS = [
-    "gross_revenue_eur",
-    "energy_cost_eur",
-    "opex_eur",
-    "debt_service_eur",
-    "market_value_eur",
-    "outstanding_debt_eur",
-    "it_load_mw",
-    "leased_capacity_mw",
-]
-
-DSCR_WATCH = 1.35
-DSCR_BREACH = 1.20
-LTV_WATCH = 74.0
-LTV_BREACH = 78.0
+from data_center_etl_pipeline.generate_asset_silver import generate_asset_silver
+from data_center_etl_pipeline.generate_bronze_tables import generate_bronze_tables
+from data_center_etl_pipeline.generate_gold_tables import generate_gold_tables
+from data_center_etl_pipeline.io import read_csv, write_csv
+from data_center_etl_pipeline.pipeline import run_etl
 
 
-@dataclass
-class Paths:
-    bronze: str
-    silver: str
-    gold: str
-
-
-def read_csv(path: str) -> List[Dict[str, str]]:
-    with open(path, "r", encoding="utf-8", newline="") as f:
-        return list(csv.DictReader(f))
-
-
-def write_csv(path: str, rows: Iterable[Dict[str, object]]) -> None:
-    rows = list(rows)
-    if not rows:
-        raise ValueError(f"Refusing to write empty dataset to {path}")
-    fieldnames = list(rows[0].keys())
-    os.makedirs(os.path.dirname(path), exist_ok=True)
-    with open(path, "w", encoding="utf-8", newline="") as f:
-        writer = csv.DictWriter(f, fieldnames=fieldnames)
-        writer.writeheader()
-        writer.writerows(rows)
-
-
-def _parse_float(value: str) -> float:
-    return float(value.strip())
-
-
-def bronze_transform(raw_rows: List[Dict[str, str]]) -> List[Dict[str, object]]:
-    now = datetime.now(timezone.utc).isoformat()
-    output = []
-    for row in raw_rows:
-        combined = "|".join(str(row[k]) for k in sorted(row.keys()))
-        row_hash = hashlib.sha256(combined.encode("utf-8")).hexdigest()
-        is_numeric = True
-        for field in NUMERIC_FIELDS:
-            try:
-                _parse_float(row[field])
-            except (KeyError, ValueError, AttributeError):
-                is_numeric = False
-                break
-
-        enriched = dict(row)
-        enriched["_ingested_at"] = now
-        enriched["_row_hash"] = row_hash
-        enriched["_is_valid_numeric"] = str(is_numeric).lower()
-        output.append(enriched)
-    return output
-
-
-def covenant_status(dscr: float, ltv: float) -> str:
-    if dscr < DSCR_BREACH or ltv > LTV_BREACH:
-        return "breach"
-    if dscr < DSCR_WATCH or ltv > LTV_WATCH:
-        return "watch"
-    return "ok"
-
-
-def silver_transform(bronze_rows: List[Dict[str, object]]) -> List[Dict[str, object]]:
-    output = []
-    for row in bronze_rows:
-        if row.get("_is_valid_numeric") != "true":
-            continue
-
-        gross_revenue = _parse_float(str(row["gross_revenue_eur"]))
-        energy_cost = _parse_float(str(row["energy_cost_eur"]))
-        opex = _parse_float(str(row["opex_eur"]))
-        debt_service = _parse_float(str(row["debt_service_eur"]))
-        market_value = _parse_float(str(row["market_value_eur"]))
-        debt_out = _parse_float(str(row["outstanding_debt_eur"]))
-        it_load = _parse_float(str(row["it_load_mw"]))
-        leased = _parse_float(str(row["leased_capacity_mw"]))
-
-        noi = gross_revenue - energy_cost - opex
-        dscr = noi / debt_service if debt_service else 0.0
-        ltv = (debt_out / market_value * 100.0) if market_value else 0.0
-        occupancy = (leased / it_load * 100.0) if it_load else 0.0
-        energy_ratio = (energy_cost / gross_revenue * 100.0) if gross_revenue else 0.0
-
-        output.append(
-            {
-                "facility_id": row["facility_id"],
-                "sponsor": row["sponsor"],
-                "country": row["country"],
-                "report_date": row["report_date"],
-                "noi_eur": round(noi, 2),
-                "dscr": round(dscr, 3),
-                "ltv_pct": round(ltv, 2),
-                "occupancy_pct": round(occupancy, 2),
-                "energy_cost_ratio_pct": round(energy_ratio, 2),
-                "junior_note_watch_status": covenant_status(dscr, ltv),
-            }
-        )
-    return output
-
-
-def gold_transform(silver_rows: List[Dict[str, object]]) -> Dict[str, List[Dict[str, object]]]:
-    sponsor_rollup: Dict[str, Dict[str, object]] = {}
-    breaches = 0
-    watch = 0
-
-    for row in silver_rows:
-        sponsor = str(row["sponsor"])
-        bucket = sponsor_rollup.setdefault(
-            sponsor,
-            {
-                "sponsor": sponsor,
-                "facility_count": 0,
-                "avg_dscr": 0.0,
-                "avg_ltv_pct": 0.0,
-                "avg_occupancy_pct": 0.0,
-                "breach_count": 0,
-                "watch_count": 0,
-            },
-        )
-
-        bucket["facility_count"] += 1
-        bucket["avg_dscr"] += float(row["dscr"])
-        bucket["avg_ltv_pct"] += float(row["ltv_pct"])
-        bucket["avg_occupancy_pct"] += float(row["occupancy_pct"])
-
-        status = str(row["junior_note_watch_status"])
-        if status == "breach":
-            bucket["breach_count"] += 1
-            breaches += 1
-        elif status == "watch":
-            bucket["watch_count"] += 1
-            watch += 1
-
-    sponsor_rows = []
-    for bucket in sponsor_rollup.values():
-        count = bucket["facility_count"]
-        bucket["avg_dscr"] = round(bucket["avg_dscr"] / count, 3)
-        bucket["avg_ltv_pct"] = round(bucket["avg_ltv_pct"] / count, 2)
-        bucket["avg_occupancy_pct"] = round(bucket["avg_occupancy_pct"] / count, 2)
-        sponsor_rows.append(bucket)
-
-    portfolio_row = {
-        "as_of": datetime.now(timezone.utc).date().isoformat(),
-        "facility_count": len(silver_rows),
-        "avg_dscr": round(sum(float(r["dscr"]) for r in silver_rows) / len(silver_rows), 3),
-        "avg_ltv_pct": round(sum(float(r["ltv_pct"]) for r in silver_rows) / len(silver_rows), 2),
-        "avg_occupancy_pct": round(sum(float(r["occupancy_pct"]) for r in silver_rows) / len(silver_rows), 2),
-        "watch_count": watch,
-        "breach_count": breaches,
-    }
-
-    return {
-        "sponsor_rollup": sponsor_rows,
-        "portfolio_dashboard": [portfolio_row],
-    }
-
-
-def run_etl(input_csv: str, output_root: str) -> Paths:
+def run_stage(input_csv: str, output_root: str, stage_name: str) -> None:
     bronze_path = os.path.join(output_root, "bronze", "facility_bronze.csv")
     silver_path = os.path.join(output_root, "silver", "facility_silver.csv")
     gold_sponsor_path = os.path.join(output_root, "gold", "sponsor_rollup.csv")
     gold_dashboard_path = os.path.join(output_root, "gold", "portfolio_dashboard.csv")
 
-    raw = read_csv(input_csv)
-    bronze = bronze_transform(raw)
-    silver = silver_transform(bronze)
-    gold = gold_transform(silver)
+    if stage_name == "bronze":
+        raw_rows = read_csv(input_csv)
+        write_csv(bronze_path, generate_bronze_tables(raw_rows))
+        print(f"Bronze: {bronze_path}")
+        return
 
-    write_csv(bronze_path, bronze)
-    write_csv(silver_path, silver)
-    write_csv(gold_sponsor_path, gold["sponsor_rollup"])
-    write_csv(gold_dashboard_path, gold["portfolio_dashboard"])
+    if stage_name == "silver":
+        bronze_rows = read_csv(bronze_path)
+        write_csv(silver_path, generate_asset_silver(bronze_rows))
+        print(f"Silver: {silver_path}")
+        return
 
-    return Paths(bronze=bronze_path, silver=silver_path, gold=os.path.dirname(gold_sponsor_path))
+    if stage_name == "gold":
+        silver_rows = read_csv(silver_path)
+        gold_tables = generate_gold_tables(silver_rows)
+        write_csv(gold_sponsor_path, gold_tables["sponsor_rollup"])
+        write_csv(gold_dashboard_path, gold_tables["portfolio_dashboard"])
+        print(f"Gold:   {os.path.dirname(gold_sponsor_path)}")
+        return
+
+    paths = run_etl(input_csv, output_root)
+    print(f"Bronze: {paths.bronze}")
+    print(f"Silver: {paths.silver}")
+    print(f"Gold:   {paths.gold}")
 
 
 def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Run the data-center ETL MVP")
+    parser = argparse.ArgumentParser(description="Run the data-center ETL pipeline")
     parser.add_argument("--input", required=True, help="Path to raw facility CSV")
     parser.add_argument("--output", required=True, help="Output folder for bronze/silver/gold layers")
+    parser.add_argument(
+        "--stage-name",
+        default="all",
+        choices=["bronze", "silver", "gold", "all"],
+        help="Name of the ETL stage to run.",
+    )
     return parser.parse_args()
 
 
 def main() -> None:
     args = parse_args()
-    paths = run_etl(args.input, args.output)
-    print(f"Bronze: {paths.bronze}")
-    print(f"Silver: {paths.silver}")
-    print(f"Gold:   {paths.gold}")
+    run_stage(args.input, args.output, args.stage_name)
 
 
 if __name__ == "__main__":

--- a/etl-pipelines/exotic/data-centers/src/data_center_etl_pipeline/__init__.py
+++ b/etl-pipelines/exotic/data-centers/src/data_center_etl_pipeline/__init__.py
@@ -1,0 +1,5 @@
+"""Data-center ETL pipeline package with bronze/silver/gold stages."""
+
+from .pipeline import run_etl
+
+__all__ = ["run_etl"]

--- a/etl-pipelines/exotic/data-centers/src/data_center_etl_pipeline/constants.py
+++ b/etl-pipelines/exotic/data-centers/src/data_center_etl_pipeline/constants.py
@@ -1,0 +1,15 @@
+NUMERIC_FIELDS = [
+    "gross_revenue_eur",
+    "energy_cost_eur",
+    "opex_eur",
+    "debt_service_eur",
+    "market_value_eur",
+    "outstanding_debt_eur",
+    "it_load_mw",
+    "leased_capacity_mw",
+]
+
+DSCR_WATCH = 1.35
+DSCR_BREACH = 1.20
+LTV_WATCH = 74.0
+LTV_BREACH = 78.0

--- a/etl-pipelines/exotic/data-centers/src/data_center_etl_pipeline/generate_asset_silver.py
+++ b/etl-pipelines/exotic/data-centers/src/data_center_etl_pipeline/generate_asset_silver.py
@@ -1,0 +1,55 @@
+from typing import Dict, List
+
+from .constants import DSCR_BREACH, DSCR_WATCH, LTV_BREACH, LTV_WATCH
+
+
+def _parse_float(value: str) -> float:
+    return float(value.strip())
+
+
+def _covenant_status(dscr: float, ltv: float) -> str:
+    if dscr < DSCR_BREACH or ltv > LTV_BREACH:
+        return "breach"
+    if dscr < DSCR_WATCH or ltv > LTV_WATCH:
+        return "watch"
+    return "ok"
+
+
+def generate_asset_silver(bronze_rows: List[Dict[str, object]]) -> List[Dict[str, object]]:
+    silver_rows: List[Dict[str, object]] = []
+
+    for row in bronze_rows:
+        if row.get("_is_valid_numeric") != "true":
+            continue
+
+        gross_revenue = _parse_float(str(row["gross_revenue_eur"]))
+        energy_cost = _parse_float(str(row["energy_cost_eur"]))
+        opex = _parse_float(str(row["opex_eur"]))
+        debt_service = _parse_float(str(row["debt_service_eur"]))
+        market_value = _parse_float(str(row["market_value_eur"]))
+        debt_out = _parse_float(str(row["outstanding_debt_eur"]))
+        it_load = _parse_float(str(row["it_load_mw"]))
+        leased = _parse_float(str(row["leased_capacity_mw"]))
+
+        noi = gross_revenue - energy_cost - opex
+        dscr = noi / debt_service if debt_service else 0.0
+        ltv = (debt_out / market_value * 100.0) if market_value else 0.0
+        occupancy = (leased / it_load * 100.0) if it_load else 0.0
+        energy_ratio = (energy_cost / gross_revenue * 100.0) if gross_revenue else 0.0
+
+        silver_rows.append(
+            {
+                "facility_id": row["facility_id"],
+                "sponsor": row["sponsor"],
+                "country": row["country"],
+                "report_date": row["report_date"],
+                "noi_eur": round(noi, 2),
+                "dscr": round(dscr, 3),
+                "ltv_pct": round(ltv, 2),
+                "occupancy_pct": round(occupancy, 2),
+                "energy_cost_ratio_pct": round(energy_ratio, 2),
+                "junior_note_watch_status": _covenant_status(dscr, ltv),
+            }
+        )
+
+    return silver_rows

--- a/etl-pipelines/exotic/data-centers/src/data_center_etl_pipeline/generate_bronze_tables.py
+++ b/etl-pipelines/exotic/data-centers/src/data_center_etl_pipeline/generate_bronze_tables.py
@@ -1,0 +1,34 @@
+import hashlib
+from datetime import datetime, timezone
+from typing import Dict, List
+
+from .constants import NUMERIC_FIELDS
+
+
+def _parse_float(value: str) -> float:
+    return float(value.strip())
+
+
+def generate_bronze_tables(raw_rows: List[Dict[str, str]]) -> List[Dict[str, object]]:
+    ingested_at = datetime.now(timezone.utc).isoformat()
+    bronze_rows: List[Dict[str, object]] = []
+
+    for row in raw_rows:
+        combined = "|".join(str(row[k]) for k in sorted(row.keys()))
+        row_hash = hashlib.sha256(combined.encode("utf-8")).hexdigest()
+
+        is_numeric = True
+        for field in NUMERIC_FIELDS:
+            try:
+                _parse_float(row[field])
+            except (KeyError, ValueError, AttributeError):
+                is_numeric = False
+                break
+
+        enriched = dict(row)
+        enriched["_ingested_at"] = ingested_at
+        enriched["_row_hash"] = row_hash
+        enriched["_is_valid_numeric"] = str(is_numeric).lower()
+        bronze_rows.append(enriched)
+
+    return bronze_rows

--- a/etl-pipelines/exotic/data-centers/src/data_center_etl_pipeline/generate_gold_tables.py
+++ b/etl-pipelines/exotic/data-centers/src/data_center_etl_pipeline/generate_gold_tables.py
@@ -1,0 +1,59 @@
+from datetime import datetime, timezone
+from typing import Dict, List
+
+
+def generate_gold_tables(silver_rows: List[Dict[str, object]]) -> Dict[str, List[Dict[str, object]]]:
+    sponsor_rollup: Dict[str, Dict[str, object]] = {}
+    breaches = 0
+    watch = 0
+
+    for row in silver_rows:
+        sponsor = str(row["sponsor"])
+        bucket = sponsor_rollup.setdefault(
+            sponsor,
+            {
+                "sponsor": sponsor,
+                "facility_count": 0,
+                "avg_dscr": 0.0,
+                "avg_ltv_pct": 0.0,
+                "avg_occupancy_pct": 0.0,
+                "breach_count": 0,
+                "watch_count": 0,
+            },
+        )
+
+        bucket["facility_count"] += 1
+        bucket["avg_dscr"] += float(row["dscr"])
+        bucket["avg_ltv_pct"] += float(row["ltv_pct"])
+        bucket["avg_occupancy_pct"] += float(row["occupancy_pct"])
+
+        status = str(row["junior_note_watch_status"])
+        if status == "breach":
+            bucket["breach_count"] += 1
+            breaches += 1
+        elif status == "watch":
+            bucket["watch_count"] += 1
+            watch += 1
+
+    sponsor_rows = []
+    for bucket in sponsor_rollup.values():
+        count = bucket["facility_count"]
+        bucket["avg_dscr"] = round(bucket["avg_dscr"] / count, 3)
+        bucket["avg_ltv_pct"] = round(bucket["avg_ltv_pct"] / count, 2)
+        bucket["avg_occupancy_pct"] = round(bucket["avg_occupancy_pct"] / count, 2)
+        sponsor_rows.append(bucket)
+
+    portfolio_row = {
+        "as_of": datetime.now(timezone.utc).date().isoformat(),
+        "facility_count": len(silver_rows),
+        "avg_dscr": round(sum(float(r["dscr"]) for r in silver_rows) / len(silver_rows), 3),
+        "avg_ltv_pct": round(sum(float(r["ltv_pct"]) for r in silver_rows) / len(silver_rows), 2),
+        "avg_occupancy_pct": round(sum(float(r["occupancy_pct"]) for r in silver_rows) / len(silver_rows), 2),
+        "watch_count": watch,
+        "breach_count": breaches,
+    }
+
+    return {
+        "sponsor_rollup": sponsor_rows,
+        "portfolio_dashboard": [portfolio_row],
+    }

--- a/etl-pipelines/exotic/data-centers/src/data_center_etl_pipeline/io.py
+++ b/etl-pipelines/exotic/data-centers/src/data_center_etl_pipeline/io.py
@@ -1,0 +1,21 @@
+import csv
+import os
+from typing import Dict, Iterable, List
+
+
+def read_csv(path: str) -> List[Dict[str, str]]:
+    with open(path, "r", encoding="utf-8", newline="") as f:
+        return list(csv.DictReader(f))
+
+
+def write_csv(path: str, rows: Iterable[Dict[str, object]]) -> None:
+    output_rows = list(rows)
+    if not output_rows:
+        raise ValueError(f"Refusing to write empty dataset to {path}")
+
+    fieldnames = list(output_rows[0].keys())
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(output_rows)

--- a/etl-pipelines/exotic/data-centers/src/data_center_etl_pipeline/pipeline.py
+++ b/etl-pipelines/exotic/data-centers/src/data_center_etl_pipeline/pipeline.py
@@ -1,0 +1,33 @@
+import os
+from dataclasses import dataclass
+
+from .generate_asset_silver import generate_asset_silver
+from .generate_bronze_tables import generate_bronze_tables
+from .generate_gold_tables import generate_gold_tables
+from .io import read_csv, write_csv
+
+
+@dataclass
+class Paths:
+    bronze: str
+    silver: str
+    gold: str
+
+
+def run_etl(input_csv: str, output_root: str) -> Paths:
+    bronze_path = os.path.join(output_root, "bronze", "facility_bronze.csv")
+    silver_path = os.path.join(output_root, "silver", "facility_silver.csv")
+    gold_sponsor_path = os.path.join(output_root, "gold", "sponsor_rollup.csv")
+    gold_dashboard_path = os.path.join(output_root, "gold", "portfolio_dashboard.csv")
+
+    raw_rows = read_csv(input_csv)
+    bronze_rows = generate_bronze_tables(raw_rows)
+    silver_rows = generate_asset_silver(bronze_rows)
+    gold_tables = generate_gold_tables(silver_rows)
+
+    write_csv(bronze_path, bronze_rows)
+    write_csv(silver_path, silver_rows)
+    write_csv(gold_sponsor_path, gold_tables["sponsor_rollup"])
+    write_csv(gold_dashboard_path, gold_tables["portfolio_dashboard"])
+
+    return Paths(bronze=bronze_path, silver=silver_path, gold=os.path.dirname(gold_sponsor_path))


### PR DESCRIPTION
Refactored the data-center ETL into a medallion-style module layout under src/data_center_etl_pipeline, with dedicated stage files for bronze (generate_bronze_tables), silver (generate_asset_silver), gold (generate_gold_tables), plus shared I/O and orchestration entrypoints.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b9c9fbaee08328b75f89aed03789f6)