### PR TITLE
Add ROADMAP.md outlining next 30/90 day priorities

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,25 @@
+# ROADMAP
+
+## Next 30 days (3 items)
+
+1. **Improve top-level onboarding docs**
+   - Tighten the root `readme.md` “Get Started” section with a clearer first-run path across ETL, API, app-library, and MCP server.
+   - Add a short “Where to start” table for new contributors.
+
+2. **Add a contributor quickstart guide**
+   - Create a short checklist-based guide linked from `CONTRIBUTING.md` (clone, choose area, run basic checks, open PR).
+   - Keep it beginner-friendly and aligned with existing PR/issue templates.
+
+3. **Publish one simple end-to-end example**
+   - Add a minimal example showing a realistic path (run one ETL sample, then inspect via API or MCP server).
+   - Focus on copy/paste commands and expected output locations.
+
+## Next 90 days (2 items)
+
+1. **Close documentation gaps surfaced by issue templates**
+   - Prioritize docs and onboarding updates based on recurring bug-report/docs-improvement/feature-request themes.
+   - Track updates in a lightweight changelog section in docs.
+
+2. **Standardize “first contribution” tasks**
+   - Add a small “good first contribution” section with low-risk tasks (doc fixes, link checks, example polish).
+   - Make contributor expectations clearer (scope, testing, PR description quality).


### PR DESCRIPTION
### Motivation

- Provide a concise roadmap to improve top-level onboarding, contributor guidance, and a minimal end-to-end example. 
- Make near-term priorities explicit so contributors can pick small, well-scoped tasks linked from existing docs like `CONTRIBUTING.md` and `readme.md`.

### Description

- Add a new `ROADMAP.md` at the repository root that lists actionable items for the next 30 and 90 days. 
- Call out three 30-day items focused on onboarding docs, a contributor quickstart, and a simple end-to-end example. 
- Call out two 90-day items to close documentation gaps and standardize “first contribution” tasks.

### Testing

- No automated tests were run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c4c4fa2e488329be36216afbfdf97e)