### PR TITLE
Docs: add API overview, improve project README, fix data-quality local path

### DIFF
--- a/api/readme.md
+++ b/api/readme.md
@@ -1,1 +1,41 @@
+# Deeploans API overview
 
+This folder contains API-related assets for the Deeploans project.
+
+## Main backend location
+
+The primary backend implementation is in:
+
+- `api/api-backend-main/backend/`
+
+Key files:
+
+- `app/server.py`: FastAPI application entrypoint
+- `app/routers.py`: API route registration
+- `openapi.json`: API schema snapshot
+
+## Quick start (local)
+
+From the repository root:
+
+```bash
+cd api/api-backend-main
+```
+
+Then follow the instructions in:
+
+- `api/api-backend-main/readme.md`
+
+## What this API provides
+
+At a high level, the backend exposes endpoints to:
+
+- access table data by credit type
+- discover schema and available filters
+- support downstream apps and analyst workflows
+
+## Related folders
+
+- `api/api-backend-main/backend/tests/`: API and filter parser tests
+- `api/api-backend-main/openapi.json`: OpenAPI metadata used by tooling
+- `mcp-server/`: MCP server that can consume API metadata

--- a/app-library/data-quality/readme.md
+++ b/app-library/data-quality/readme.md
@@ -28,7 +28,7 @@ After deployment, the app will be available at:
 ## Run locally
 
 ```bash
-cd deeploans-app
+cd app-library/data-quality
 python -m http.server 4173
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -24,6 +24,16 @@ Additional components in this repository include:
 - `app-library/`: A library of (MVP) applications that run on top of deeploans
 - `mcp-server/`: standalone MCP server for AI/client integrations
 
+## Where to start (quick navigation)
+
+If you are new to the project, start here:
+
+1. `readme.md` (this file) for a project overview.
+2. `CONTRIBUTING.md` for contribution flow and PR tips.
+3. `etl-pipelines/readme.md` for data lakehouse ETL architecture.
+4. `mcp-server/README.md` for AI/client integration setup.
+5. `api/readme.md` for backend API orientation.
+
 <p align="center">
 <img src="deeploans_overview.png" alt="Deeploans Overview" title="deeploans overview" width="400">
 </p>
@@ -31,12 +41,12 @@ Additional components in this repository include:
 
 # Licence
 
-Deeploans is available under the Apache licence. See here for [full text]([url](https://www.apache.org/licenses/LICENSE-2.0)). 
+Deeploans is available under the Apache licence. See here for [full text](https://www.apache.org/licenses/LICENSE-2.0).
 <br>
 
 # How to get involved
 
-deeploans is a growing open-source project where developers and data analysts can directly shape the future of their tools and infrastructure. 
+deeploans is a growing open-source project where developers and data analysts can directly shape the future of their tools and infrastructure.
 
 🛠 **Help build deeploans**
 <br>
@@ -57,7 +67,7 @@ Documentation is everything. If something unclear or missing, your contributions
 
 💡**Feature requests & ideas**
 <br>
-Got a use case we haven’t covered? Open an issue or drop a comment in [Discussions]([url](https://github.com/orgs/Algoritmica-ai/discussions)) to brainstorm.
+Got a use case we haven’t covered? Open an issue or drop a comment in [Discussions](https://github.com/orgs/Algoritmica-ai/discussions) to brainstorm.
 <br>
 
 ## Get started
@@ -78,8 +88,8 @@ To get in touch, drop an email at:
 
 # deeploans background
 
-deeploans began as an AI-powered analytics tool designed to help portfolio managers predict default risk. 
+deeploans began as an AI-powered analytics tool designed to help portfolio managers predict default risk.
 
 However, we quickly recognised a fundamental challenge: before the market can adopt more advanced tools, it needs clean and better-structured data.
 
-Thus, deeploans evolved into an open data infrastructure project. Today, deeploans solves the fragmented, inconsistent and incomplete data problem in finance, enabling analysts and developers to build better tools. 
+Thus, deeploans evolved into an open data infrastructure project. Today, deeploans solves the fragmented, inconsistent and incomplete data problem in finance, enabling analysts and developers to build better tools.


### PR DESCRIPTION
### Motivation

- Provide a clear entry point for the backend by adding an API overview to orient contributors and tooling. 
- Improve newcomer onboarding by surfacing a concise "Where to start" navigation in the top-level `readme.md`.
- Fix a local-run path in the data-quality app readme so instructions match the repository layout.

### Description

- Added `api/readme.md` with the backend location, key files (`app/server.py`, `app/routers.py`, `openapi.json`), a quick-start guide, and related folders. 
- Updated `app-library/data-quality/readme.md` to correct the local run command to `cd app-library/data-quality` and start a simple HTTP server. 
- Enhanced the top-level `readme.md` with a "Where to start (quick navigation)" section, fixed Markdown link formatting, and minor phrasing/spacing cleanups. 

### Testing

- No automated tests were run because this change is documentation-only and does not modify executable code.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69df182213048329aafda4e47f205137)