### PR TITLE
docs: add repository hygiene guidance and quick-start personas; fix README links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,17 @@ Before you submit, please:
 - update docs if needed
 - check for obvious formatting or link issues
 
+## Repository hygiene
+
+To keep the repository clean and reviewable, please avoid committing generated or local-only files:
+
+- Python caches (for example `__pycache__/`, `*.pyc`)
+- Local OS files (for example `.DS_Store`)
+- ETL run outputs and temporary dumps generated during local experiments
+
+If your change needs sample output for documentation, prefer a tiny, curated fixture in a clearly named folder and explain why it is required in the PR.
+
+
 ## Commit message guidance
 
 If possible, use one of these prefixes:

--- a/readme.md
+++ b/readme.md
@@ -31,7 +31,7 @@ Additional components in this repository include:
 
 # Licence
 
-Deeploans is available under the Apache licence. See here for [full text]([url](https://www.apache.org/licenses/LICENSE-2.0)). 
+Deeploans is available under the Apache licence. See the [full text](https://www.apache.org/licenses/LICENSE-2.0). 
 <br>
 
 # How to get involved
@@ -57,7 +57,7 @@ Documentation is everything. If something unclear or missing, your contributions
 
 💡**Feature requests & ideas**
 <br>
-Got a use case we haven’t covered? Open an issue or drop a comment in [Discussions]([url](https://github.com/orgs/Algoritmica-ai/discussions)) to brainstorm.
+Got a use case we haven’t covered? Open an issue or drop a comment in [Discussions](https://github.com/orgs/Algoritmica-ai/discussions) to brainstorm.
 <br>
 
 ## Get started
@@ -68,6 +68,15 @@ Got a use case we haven’t covered? Open an issue or drop a comment in [Discuss
 - Once issues are posted, grab one and submit a pull request when you're ready.
 - Stay tuned to join the community on Discord!
 <br>
+
+
+
+## Quick start by persona
+
+- **Data analyst**: Start with [`etl-pipelines/readme.md`](etl-pipelines/readme.md) for lakehouse context, asset classes, and ETL workflow assumptions.
+- **API consumer**: Go to [`api/api-backend-main/readme.md`](api/api-backend-main/readme.md) for backend setup requirements and endpoint usage.
+- **AI / MCP integrator**: Use [`mcp-server/README.md`](mcp-server/README.md) to run the standalone MCP server and connect it to your MCP client.
+- **Contributor**: Read [`CONTRIBUTING.md`](CONTRIBUTING.md) and [`cla.md`](cla.md) before opening a PR.
 
 
 # Contacts


### PR DESCRIPTION
### Motivation

- Improve contributor onboarding by adding guidance on what not to commit and how to include sample outputs. 
- Clarify README links and provide targeted quick-start entry points by role to reduce navigation friction. 
- Make repository expectations clearer so reviews focus on relevant code changes.

### Description

- Added a `Repository hygiene` section to `CONTRIBUTING.md` that lists files to avoid committing (for example `__pycache__/`, `*.pyc`, `.DS_Store`, ETL run outputs) and guidance for including curated fixtures. 
- Updated `readme.md` to fix link formatting for the Apache license and Discussions URL. 
- Added a `Quick start by persona` section to `readme.md` with direct links to `etl-pipelines/readme.md`, `api/api-backend-main/readme.md`, `mcp-server/README.md`, and `CONTRIBUTING.md`/`cla.md` for contributors. 
- Minor copy and formatting cleanups in `readme.md` to improve clarity.

### Testing

- No automated tests were run because these are documentation-only changes and do not affect code behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e1b13ce820832983d30213c59ed4ab)