### PR TITLE
Add fm_sequences utilities to generate event sequences from SME and RMB snapshots

### DIFF
--- a/etl-pipelines/common_components/README.md
+++ b/etl-pipelines/common_components/README.md
@@ -1,1 +1,6 @@
 ## Common Components
+
+### Foundation-model sequence utilities
+- `fm_sequences/sequence_generator.py`: first-pass sequence schema + generator for SME and residential mortgage ETL snapshots.
+- `fm_sequences/configs/sme_rmb_token_mapping.sample.json`: sample feature/token mapping config.
+- `fm_sequences/README.md`: quick guide on inputs, outputs, and assumptions.

--- a/etl-pipelines/common_components/fm_sequences/README.md
+++ b/etl-pipelines/common_components/fm_sequences/README.md
@@ -1,0 +1,20 @@
+# FM Sequences: SME + Residential Mortgage (first pass)
+
+## Inputs
+- `sme_snapshots`: list of dict-like rows from SME asset-level ETL outputs (expects columns such as `AS3`, `AS1`, `AS27`, `AS30`, etc.).
+- `rmb_snapshots`: list of dict-like rows from residential mortgage ETL outputs (expects columns such as `AR3`, `AR1`, `AR19`, `AR24`, etc.).
+- Optional config reference: `configs/sme_rmb_token_mapping.sample.json`.
+
+## Outputs
+- `SequenceEvent` objects with:
+  - `entity_type`, `entity_id`, `as_of_date`
+  - `sequence_index` (global deterministic order)
+  - `event_kind` (`entity_initialized` or `attribute_updated`)
+  - `token`, `value`, `source_schema`
+- Optional rendered strings via `render_for_tokenization(...)`.
+
+## Assumptions
+- Input rows are already available in memory as dictionaries.
+- This is schema-first and non-invasive: no ETL pipeline wiring is changed.
+- Missing feature values are emitted as `__MISSING__` by default (can be disabled).
+- If no explicit date exists, `pcd_year`/`pcd_month` are used; fallback is `1970-01-01`.

--- a/etl-pipelines/common_components/fm_sequences/__init__.py
+++ b/etl-pipelines/common_components/fm_sequences/__init__.py
@@ -1,0 +1,23 @@
+"""Utilities for transforming Deeploans snapshots into event sequences."""
+
+from .sequence_generator import (
+    RMB_FIRST_PASS_SCHEMA,
+    SME_FIRST_PASS_SCHEMA,
+    FeatureToken,
+    SequenceEvent,
+    SequenceSchema,
+    build_sme_rmb_event_sequence,
+    generate_events,
+    render_for_tokenization,
+)
+
+__all__ = [
+    "FeatureToken",
+    "RMB_FIRST_PASS_SCHEMA",
+    "SME_FIRST_PASS_SCHEMA",
+    "SequenceEvent",
+    "SequenceSchema",
+    "build_sme_rmb_event_sequence",
+    "generate_events",
+    "render_for_tokenization",
+]

--- a/etl-pipelines/common_components/fm_sequences/configs/sme_rmb_token_mapping.sample.json
+++ b/etl-pipelines/common_components/fm_sequences/configs/sme_rmb_token_mapping.sample.json
@@ -1,0 +1,34 @@
+{
+  "schemas": [
+    {
+      "name": "ecb_sme_asset_silver_v1",
+      "entity_type": "sme_loan",
+      "id_fields": ["AS3", "loan_id", "asset_id"],
+      "time_fields": ["AS1", "snapshot_date", "as_of_date", "report_date"],
+      "features": [
+        {"column": "dl_code", "token": "asset_class"},
+        {"column": "AS2", "token": "obligor_id"},
+        {"column": "AS27", "token": "orig_balance"},
+        {"column": "AS30", "token": "current_balance"},
+        {"column": "AS54", "token": "interest_rate"},
+        {"column": "AS115", "token": "arrears_balance"},
+        {"column": "AS121", "token": "forbearance_flag", "missing_token": "__MISSING__"}
+      ]
+    },
+    {
+      "name": "ecb_rmb_asset_silver_v1",
+      "entity_type": "resi_mortgage",
+      "id_fields": ["AR3", "loan_id", "asset_id"],
+      "time_fields": ["AR1", "snapshot_date", "as_of_date", "report_date"],
+      "features": [
+        {"column": "dl_code", "token": "asset_class"},
+        {"column": "AR2", "token": "originator_loan_ref"},
+        {"column": "AR19", "token": "orig_balance"},
+        {"column": "AR24", "token": "current_balance"},
+        {"column": "AR31", "token": "interest_rate"},
+        {"column": "AR90", "token": "arrears_balance"},
+        {"column": "AR122", "token": "restructured_flag", "missing_token": "__MISSING__"}
+      ]
+    }
+  ]
+}

--- a/etl-pipelines/common_components/fm_sequences/sequence_generator.py
+++ b/etl-pipelines/common_components/fm_sequences/sequence_generator.py
@@ -1,0 +1,248 @@
+"""Sequence generation utilities for SME and residential mortgage snapshots."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, datetime
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
+
+
+@dataclass(frozen=True)
+class FeatureToken:
+    """Map a source column to an output token key."""
+
+    column: str
+    token: str
+    missing_token: str = "__MISSING__"
+
+
+@dataclass(frozen=True)
+class SequenceSchema:
+    """Schema that converts ETL snapshots into token events."""
+
+    name: str
+    entity_type: str
+    id_fields: Tuple[str, ...]
+    time_fields: Tuple[str, ...]
+    features: Tuple[FeatureToken, ...]
+
+
+@dataclass(frozen=True)
+class SequenceEvent:
+    entity_type: str
+    entity_id: str
+    as_of_date: str
+    sequence_index: int
+    event_kind: str
+    token: str
+    value: str
+    source_schema: str
+
+    def to_dict(self) -> Dict[str, str | int]:
+        return {
+            "entity_type": self.entity_type,
+            "entity_id": self.entity_id,
+            "as_of_date": self.as_of_date,
+            "sequence_index": self.sequence_index,
+            "event_kind": self.event_kind,
+            "token": self.token,
+            "value": self.value,
+            "source_schema": self.source_schema,
+        }
+
+
+SME_FIRST_PASS_SCHEMA = SequenceSchema(
+    name="ecb_sme_asset_silver_v1",
+    entity_type="sme_loan",
+    id_fields=("AS3", "loan_id", "asset_id"),
+    time_fields=("AS1", "snapshot_date", "as_of_date", "report_date"),
+    features=(
+        FeatureToken("dl_code", "asset_class"),
+        FeatureToken("AS2", "obligor_id"),
+        FeatureToken("AS27", "orig_balance"),
+        FeatureToken("AS30", "current_balance"),
+        FeatureToken("AS54", "interest_rate"),
+        FeatureToken("AS115", "arrears_balance"),
+        FeatureToken("AS121", "forbearance_flag"),
+    ),
+)
+
+RMB_FIRST_PASS_SCHEMA = SequenceSchema(
+    name="ecb_rmb_asset_silver_v1",
+    entity_type="resi_mortgage",
+    id_fields=("AR3", "loan_id", "asset_id"),
+    time_fields=("AR1", "snapshot_date", "as_of_date", "report_date"),
+    features=(
+        FeatureToken("dl_code", "asset_class"),
+        FeatureToken("AR2", "originator_loan_ref"),
+        FeatureToken("AR19", "orig_balance"),
+        FeatureToken("AR24", "current_balance"),
+        FeatureToken("AR31", "interest_rate"),
+        FeatureToken("AR90", "arrears_balance"),
+        FeatureToken("AR122", "restructured_flag"),
+    ),
+)
+
+
+def build_sme_rmb_event_sequence(
+    sme_snapshots: Sequence[Mapping[str, Any]],
+    rmb_snapshots: Sequence[Mapping[str, Any]],
+    *,
+    include_missing_values: bool = True,
+) -> List[SequenceEvent]:
+    """Build a merged event sequence across SME and RMB snapshots."""
+
+    events = []
+    events.extend(
+        generate_events(
+            sme_snapshots,
+            SME_FIRST_PASS_SCHEMA,
+            include_missing_values=include_missing_values,
+        )
+    )
+    events.extend(
+        generate_events(
+            rmb_snapshots,
+            RMB_FIRST_PASS_SCHEMA,
+            include_missing_values=include_missing_values,
+        )
+    )
+
+    events.sort(
+        key=lambda e: (
+            e.as_of_date,
+            e.entity_type,
+            e.entity_id,
+            e.sequence_index,
+            e.token,
+        )
+    )
+
+    return [
+        SequenceEvent(
+            entity_type=e.entity_type,
+            entity_id=e.entity_id,
+            as_of_date=e.as_of_date,
+            sequence_index=index,
+            event_kind=e.event_kind,
+            token=e.token,
+            value=e.value,
+            source_schema=e.source_schema,
+        )
+        for index, e in enumerate(events)
+    ]
+
+
+def generate_events(
+    snapshots: Sequence[Mapping[str, Any]],
+    schema: SequenceSchema,
+    *,
+    include_missing_values: bool = True,
+) -> List[SequenceEvent]:
+    """Convert snapshots for one schema into tokenizable events."""
+
+    grouped: Dict[str, List[Tuple[str, Mapping[str, Any], int]]] = {}
+    for row_index, snapshot in enumerate(snapshots):
+        entity_id = _first_non_empty(snapshot, schema.id_fields)
+        if entity_id is None:
+            continue
+
+        as_of_date = _extract_as_of_date(snapshot, schema.time_fields)
+        grouped.setdefault(entity_id, []).append((as_of_date, snapshot, row_index))
+
+    events: List[SequenceEvent] = []
+    for entity_id, rows in grouped.items():
+        rows.sort(key=lambda item: (item[0], item[2]))
+        previous_token_values: Dict[str, str] = {}
+
+        for snapshot_idx, (as_of_date, row, _) in enumerate(rows):
+            event_kind = "entity_initialized" if snapshot_idx == 0 else "attribute_updated"
+            for feature in schema.features:
+                raw_value = row.get(feature.column)
+                normalized = _normalize_value(raw_value)
+
+                if normalized is None:
+                    if not include_missing_values:
+                        continue
+                    normalized = feature.missing_token
+
+                previous_value = previous_token_values.get(feature.token)
+                if snapshot_idx == 0 or normalized != previous_value:
+                    events.append(
+                        SequenceEvent(
+                            entity_type=schema.entity_type,
+                            entity_id=entity_id,
+                            as_of_date=as_of_date,
+                            sequence_index=snapshot_idx,
+                            event_kind=event_kind,
+                            token=feature.token,
+                            value=normalized,
+                            source_schema=schema.name,
+                        )
+                    )
+
+                previous_token_values[feature.token] = normalized
+
+    return events
+
+
+def render_for_tokenization(events: Iterable[SequenceEvent]) -> List[str]:
+    return [
+        (
+            f"schema={event.source_schema} type={event.entity_type} "
+            f"id={event.entity_id} date={event.as_of_date} "
+            f"token={event.token} value={event.value}"
+        )
+        for event in events
+    ]
+
+
+def _extract_as_of_date(snapshot: Mapping[str, Any], time_fields: Sequence[str]) -> str:
+    raw_value = _first_non_empty(snapshot, time_fields)
+    if raw_value:
+        parsed = _parse_date(raw_value)
+        if parsed is not None:
+            return parsed
+        return str(raw_value).strip()
+
+    year = snapshot.get("pcd_year")
+    month = snapshot.get("pcd_month")
+    if year is not None and month is not None:
+        return f"{int(year):04d}-{int(month):02d}-01"
+
+    return "1970-01-01"
+
+
+def _parse_date(value: Any) -> Optional[str]:
+    if isinstance(value, datetime):
+        return value.date().isoformat()
+    if isinstance(value, date):
+        return value.isoformat()
+
+    text = str(value).strip()
+    if not text:
+        return None
+
+    for fmt in ("%Y-%m-%d", "%Y/%m/%d", "%d/%m/%Y", "%Y-%m-%d %H:%M:%S"):
+        try:
+            return datetime.strptime(text, fmt).date().isoformat()
+        except ValueError:
+            continue
+    return None
+
+
+def _first_non_empty(snapshot: Mapping[str, Any], candidates: Sequence[str]) -> Optional[str]:
+    for candidate in candidates:
+        if candidate not in snapshot:
+            continue
+        normalized = _normalize_value(snapshot[candidate])
+        if normalized is not None:
+            return normalized
+    return None
+
+
+def _normalize_value(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text if text else None

--- a/etl-pipelines/common_components/fm_sequences/tests/test_sequence_generator.py
+++ b/etl-pipelines/common_components/fm_sequences/tests/test_sequence_generator.py
@@ -1,0 +1,41 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from fm_sequences.sequence_generator import (  # noqa: E402
+    SME_FIRST_PASS_SCHEMA,
+    generate_events,
+)
+
+
+def test_sequence_ordering_for_same_entity_by_date_then_input_order():
+    snapshots = [
+        {"AS3": "L-1", "AS1": "2025-02-01", "AS30": 90},
+        {"AS3": "L-1", "AS1": "2025-01-01", "AS30": 100},
+        {"AS3": "L-1", "AS1": "2025-02-01", "AS30": 80},
+    ]
+
+    events = generate_events(snapshots, SME_FIRST_PASS_SCHEMA)
+    current_balance_events = [e for e in events if e.token == "current_balance"]
+
+    assert [e.as_of_date for e in current_balance_events] == [
+        "2025-01-01",
+        "2025-02-01",
+        "2025-02-01",
+    ]
+    assert [e.value for e in current_balance_events] == ["100", "90", "80"]
+
+
+def test_missing_values_emit_missing_token_and_missing_id_rows_are_skipped():
+    snapshots = [
+        {"AS3": "L-2", "AS1": "2025-03-01", "AS121": None},
+        {"AS1": "2025-04-01", "AS121": "Y"},
+    ]
+
+    events = generate_events(snapshots, SME_FIRST_PASS_SCHEMA, include_missing_values=True)
+
+    forbearance_events = [e for e in events if e.token == "forbearance_flag"]
+    assert len(forbearance_events) == 1
+    assert forbearance_events[0].value == "__MISSING__"
+    assert all(event.entity_id == "L-2" for event in events)


### PR DESCRIPTION
### Motivation
- Provide a schema-first utility to transform SME and residential mortgage ETL snapshots into deterministic event sequences for foundation-model tokenization.
- Support deterministic ordering across snapshots, simple missing-value handling, and a non-invasive workflow that does not alter existing ETL pipelines.
- Offer a first-pass implementation for SME and residential mortgage schemas to accelerate prototyping and token mapping configuration.

### Description
- Add `fm_sequences/sequence_generator.py` implementing `FeatureToken`, `SequenceSchema`, `SequenceEvent`, `generate_events`, `build_sme_rmb_event_sequence`, `render_for_tokenization`, and helper functions for date extraction and normalization.
- Provide two first-pass schemas as constants: `SME_FIRST_PASS_SCHEMA` and `RMB_FIRST_PASS_SCHEMA` for SME and residential mortgage sources respectively.
- Add package exports in `fm_sequences/__init__.py`, a sample mapping config at `configs/sme_rmb_token_mapping.sample.json`, and READMEs documenting inputs, outputs, and assumptions.
- Add unit tests in `fm_sequences/tests/test_sequence_generator.py` covering event ordering, snapshot input ordering, and missing-value emission behavior.

### Testing
- Ran the new unit tests with `pytest etl-pipelines/common_components/fm_sequences/tests/test_sequence_generator.py` and the tests passed.
- Validated that `generate_events` produces deterministic ordering and emits `__MISSING__` when `include_missing_values=True` as asserted by the tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69e207b76a50832897703698c029eef8)