### PR TITLE
Fix local run directory in data-quality README

### DIFF
--- a/app-library/data-quality/readme.md
+++ b/app-library/data-quality/readme.md
@@ -28,7 +28,7 @@ After deployment, the app will be available at:
 ## Run locally
 
 ```bash
-cd deeploans-app
+cd app-library/data-quality
 python -m http.server 4173
 ```
 


### PR DESCRIPTION
### Motivation
- Correct the local run instructions that referenced the wrong directory so users can serve the data-quality app locally.

### Description
- Update the `Run locally` example to change `cd deeploans-app` to `cd app-library/data-quality` so `python -m http.server 4173` serves the correct folder.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69eb002514148329ab4832c65efff158)