### PR TITLE
Add Deeploans API quickstart and fix data-quality local run path

### DIFF
--- a/api/readme.md
+++ b/api/readme.md
@@ -1,1 +1,30 @@
+# Deeploans API quickstart
 
+This folder contains the Deeploans API backend project.
+
+## Project location
+
+- Backend code: `api/api-backend-main/backend/`
+- Backend docs and setup details: `api/api-backend-main/readme.md`
+- OpenAPI schema snapshot: `api/api-backend-main/openapi.json`
+
+## Local run (Docker Compose)
+
+From the repository root:
+
+```bash
+cd api/api-backend-main
+docker compose up --build
+```
+
+The backend service runs on:
+
+- `http://localhost:3000`
+- Swagger docs: `http://localhost:3000/docs`
+
+## Notes
+
+- Create `backend/.env` before startup (use the variables documented in `api/api-backend-main/readme.md`).
+- A `backend/bigquery.json` credentials file is required to run the API locally.
+- `mongo-express` is intended for local development only.
+- For full endpoint details (including admin endpoints), see `api/api-backend-main/readme.md`.

--- a/app-library/data-quality/readme.md
+++ b/app-library/data-quality/readme.md
@@ -28,7 +28,7 @@ After deployment, the app will be available at:
 ## Run locally
 
 ```bash
-cd deeploans-app
+cd app-library/data-quality
 python -m http.server 4173
 ```
 


### PR DESCRIPTION
### Motivation
- Provide a concise quickstart for the Deeploans API backend so developers can find the project location and local run instructions in one place.
- Correct the local-run instruction for the Data Quality app which previously referenced the wrong directory.

### Description
- Add `api/readme.md` with project locations, an OpenAPI snapshot pointer, Docker Compose local run instructions (`docker compose up --build`), service endpoints (`http://localhost:3000` and `http://localhost:3000/docs`), and notes about required env/credentials files.
- Update `app-library/data-quality/readme.md` to fix the local run command directory from `cd deeploans-app` to `cd app-library/data-quality` and keep the `python -m http.server 4173` instruction.

### Testing
- No automated tests were added or modified for these documentation changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69eb002514148329ab4832c65efff158)