### PR TITLE
Add app-library README and API quickstart; fix data-quality local run path

### DIFF
--- a/api/readme.md
+++ b/api/readme.md
@@ -1,1 +1,30 @@
+# Deeploans API quickstart
 
+This folder contains the Deeploans API backend project.
+
+## Project location
+
+- Backend code: `api/api-backend-main/backend/`
+- Backend docs and setup details: `api/api-backend-main/readme.md`
+- OpenAPI schema snapshot: `api/api-backend-main/openapi.json`
+
+## Local run (Docker Compose)
+
+From the repository root:
+
+```bash
+cd api/api-backend-main
+docker compose up --build
+```
+
+The backend service runs on:
+
+- `http://localhost:3000`
+- Swagger docs: `http://localhost:3000/docs`
+
+## Notes
+
+- Create `backend/.env` before startup (use the variables documented in `api/api-backend-main/readme.md`).
+- A `backend/bigquery.json` credentials file is required to run the API locally.
+- `mongo-express` is intended for local development only.
+- For full endpoint details (including admin endpoints), see `api/api-backend-main/readme.md`.

--- a/app-library/data-quality/readme.md
+++ b/app-library/data-quality/readme.md
@@ -28,7 +28,7 @@ After deployment, the app will be available at:
 ## Run locally
 
 ```bash
-cd deeploans-app
+cd app-library/data-quality
 python -m http.server 4173
 ```
 

--- a/app-library/readme.md
+++ b/app-library/readme.md
@@ -1,0 +1,68 @@
+# Deeploans app library
+
+This folder contains lightweight MVP applications built on top of Deeploans components.
+
+## Available apps
+
+### 1) Data Quality App
+
+- Path: `app-library/data-quality/`
+- Purpose: dataset ingestion status, loan tape exploration, data-quality dashboard, API usage starter view.
+- Run locally:
+
+```bash
+cd app-library/data-quality
+python -m http.server 4173
+```
+
+Open <http://localhost:4173>.
+
+---
+
+### 2) Data Center Junior Note MVP
+
+- Path: `app-library/datacenter-junior-note/`
+- Purpose: monitor junior-note exposure, facility metrics, covenant triggers, and scenario actions.
+- Run locally:
+
+```bash
+cd app-library/datacenter-junior-note
+python -m http.server 4174
+```
+
+Open <http://localhost:4174>.
+
+---
+
+### 3) Hastructure Studio bridge
+
+- Path: `app-library/hastructure-studio/`
+- Purpose: map Deeploans loan tape data into Hastructure-style payloads.
+- Run locally:
+
+```bash
+cd app-library/hastructure-studio
+python -m http.server 4180
+```
+
+Open <http://localhost:4180>.
+
+---
+
+### 4) CMBS Data Provider Workbench
+
+- Path: `app-library/cmbs-data-provider-workbench/`
+- Purpose: CMBS monitoring UI that consumes Deeploans API data with local fallback.
+- Run locally:
+
+```bash
+cd app-library/cmbs-data-provider-workbench
+python -m http.server 4174
+```
+
+Open <http://localhost:4174>.
+
+## Related docs
+
+- Root overview: `readme.md`
+- Contribution guide: `CONTRIBUTING.md`

--- a/readme.md
+++ b/readme.md
@@ -21,7 +21,7 @@ deeploans includes ETLs for the following structured finance datasets:
 Additional components in this repository include:
 
 - `api/api-backend-main/`: FastAPI backend for data access
-- `app-library/`: A library of (MVP) applications that run on top of deeploans
+- `app-library/`: A library of (MVP) applications that run on top of deeploans (see `app-library/readme.md`)
 - `mcp-server/`: standalone MCP server for AI/client integrations
 
 <p align="center">


### PR DESCRIPTION
### Motivation

- Provide clear local run and deployment instructions for the app library and API to make onboarding easier.  
- Surface lightweight MVP apps in a top-level `app-library` overview so users can find and run example UIs.  
- Correct the local run command for the Data Quality app to point to its actual path.

### Description

- Added a new top-level apps index at `app-library/readme.md` documenting available MVP apps, their paths, and local run commands.  
- Added `api/readme.md` with a quickstart for the Deeploans API backend, service URLs, and notes about required env and credentials.  
- Updated `app-library/data-quality/readme.md` to correct the local run directory from `deeploans-app` to `app-library/data-quality` and show the `python -m http.server 4173` command.  
- Updated root `readme.md` to reference the new `app-library/readme.md` entry.

### Testing

- No automated tests were run for these documentation-only changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69eb002514148329ab4832c65efff158)