### PR TITLE
docs: add app-library overview, API quickstart, and mcp-server test instructions; fix data-quality path

### DIFF
--- a/api/readme.md
+++ b/api/readme.md
@@ -1,1 +1,30 @@
+# Deeploans API quickstart
 
+This folder contains the Deeploans API backend project.
+
+## Project location
+
+- Backend code: `api/api-backend-main/backend/`
+- Backend docs and setup details: `api/api-backend-main/readme.md`
+- OpenAPI schema snapshot: `api/api-backend-main/openapi.json`
+
+## Local run (Docker Compose)
+
+From the repository root:
+
+```bash
+cd api/api-backend-main
+docker compose up --build
+```
+
+The backend service runs on:
+
+- `http://localhost:3000`
+- Swagger docs: `http://localhost:3000/docs`
+
+## Notes
+
+- Create `backend/.env` before startup (use the variables documented in `api/api-backend-main/readme.md`).
+- A `backend/bigquery.json` credentials file is required to run the API locally.
+- `mongo-express` is intended for local development only.
+- For full endpoint details (including admin endpoints), see `api/api-backend-main/readme.md`.

--- a/app-library/data-quality/readme.md
+++ b/app-library/data-quality/readme.md
@@ -28,7 +28,7 @@ After deployment, the app will be available at:
 ## Run locally
 
 ```bash
-cd deeploans-app
+cd app-library/data-quality
 python -m http.server 4173
 ```
 

--- a/app-library/readme.md
+++ b/app-library/readme.md
@@ -1,0 +1,68 @@
+# Deeploans app library
+
+This folder contains lightweight MVP applications built on top of Deeploans components.
+
+## Available apps
+
+### 1) Data Quality App
+
+- Path: `app-library/data-quality/`
+- Purpose: dataset ingestion status, loan tape exploration, data-quality dashboard, API usage starter view.
+- Run locally:
+
+```bash
+cd app-library/data-quality
+python -m http.server 4173
+```
+
+Open <http://localhost:4173>.
+
+---
+
+### 2) Data Center Junior Note MVP
+
+- Path: `app-library/datacenter-junior-note/`
+- Purpose: monitor junior-note exposure, facility metrics, covenant triggers, and scenario actions.
+- Run locally:
+
+```bash
+cd app-library/datacenter-junior-note
+python -m http.server 4174
+```
+
+Open <http://localhost:4174>.
+
+---
+
+### 3) Hastructure Studio bridge
+
+- Path: `app-library/hastructure-studio/`
+- Purpose: map Deeploans loan tape data into Hastructure-style payloads.
+- Run locally:
+
+```bash
+cd app-library/hastructure-studio
+python -m http.server 4180
+```
+
+Open <http://localhost:4180>.
+
+---
+
+### 4) CMBS Data Provider Workbench
+
+- Path: `app-library/cmbs-data-provider-workbench/`
+- Purpose: CMBS monitoring UI that consumes Deeploans API data with local fallback.
+- Run locally:
+
+```bash
+cd app-library/cmbs-data-provider-workbench
+python -m http.server 4174
+```
+
+Open <http://localhost:4174>.
+
+## Related docs
+
+- Root overview: `readme.md`
+- Contribution guide: `CONTRIBUTING.md`

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -41,6 +41,21 @@ deeploans-mcp
 }
 ```
 
+## Testing
+
+Run unit tests from the repository root:
+
+```bash
+python -m unittest mcp-server/tests/test_server.py
+```
+
+Or from the `mcp-server` folder:
+
+```bash
+cd mcp-server
+python -m unittest tests/test_server.py
+```
+
 ## Notes
 
 - API-calling tools expect the backend to be running (default: `http://localhost:8000`).

--- a/readme.md
+++ b/readme.md
@@ -21,7 +21,7 @@ deeploans includes ETLs for the following structured finance datasets:
 Additional components in this repository include:
 
 - `api/api-backend-main/`: FastAPI backend for data access
-- `app-library/`: A library of (MVP) applications that run on top of deeploans
+- `app-library/`: A library of (MVP) applications that run on top of deeploans (see `app-library/readme.md`)
 - `mcp-server/`: standalone MCP server for AI/client integrations
 
 <p align="center">


### PR DESCRIPTION
### Motivation

- Provide clear quickstart and local-run instructions for the API backend and the lightweight app library to make local development and demos easier.
- Surface a central `app-library` overview so contributors can find and run the included MVP apps.
- Add explicit test run instructions for the `mcp-server` component and correct the local path in the Data Quality app readme.

### Description

- Added a new `app-library/readme.md` documenting available lightweight apps and local run commands for each app with example `python -m http.server` commands.
- Created `api/readme.md` with a Deeploans API quickstart that documents backend location, Docker Compose local run (`cd api/api-backend-main` then `docker compose up --build`), and service URLs.
- Updated `app-library/data-quality/readme.md` to fix the local run path to `cd app-library/data-quality` and keep the server command `python -m http.server 4173`.
- Updated the root `readme.md` to reference the new `app-library/readme.md` entry.
- Extended `mcp-server/README.md` with a `Testing` section showing how to run unit tests with `python -m unittest mcp-server/tests/test_server.py` (or from `mcp-server` folder `python -m unittest tests/test_server.py`).

### Testing

- No automated tests were executed as part of this documentation-only change.
- The `mcp-server` unit test command shown in the README is `python -m unittest mcp-server/tests/test_server.py` (or `cd mcp-server && python -m unittest tests/test_server.py`) and can be used to run tests locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69eb002514148329ab4832c65efff158)