### PR TITLE
Add standardized data quality report artifact to data-center ETL pipeline

### DIFF
--- a/etl-pipelines/exotic/data-centers/src/data_center_etl.py
+++ b/etl-pipelines/exotic/data-centers/src/data_center_etl.py
@@ -43,6 +43,7 @@ def run_stage(input_csv: str, output_root: str, stage_name: str) -> None:
     print(f"Bronze: {paths.bronze}")
     print(f"Silver: {paths.silver}")
     print(f"Gold:   {paths.gold}")
+    print(f"Quality:{paths.quality_report}")
 
 
 def parse_args() -> argparse.Namespace:

--- a/etl-pipelines/exotic/data-centers/src/data_center_etl_pipeline/pipeline.py
+++ b/etl-pipelines/exotic/data-centers/src/data_center_etl_pipeline/pipeline.py
@@ -5,6 +5,7 @@ from .generate_asset_silver import generate_asset_silver
 from .generate_bronze_tables import generate_bronze_tables
 from .generate_gold_tables import generate_gold_tables
 from .io import read_csv, write_csv
+from .quality_report import write_quality_report
 
 
 @dataclass
@@ -12,6 +13,7 @@ class Paths:
     bronze: str
     silver: str
     gold: str
+    quality_report: str
 
 
 def run_etl(input_csv: str, output_root: str) -> Paths:
@@ -19,6 +21,7 @@ def run_etl(input_csv: str, output_root: str) -> Paths:
     silver_path = os.path.join(output_root, "silver", "facility_silver.csv")
     gold_sponsor_path = os.path.join(output_root, "gold", "sponsor_rollup.csv")
     gold_dashboard_path = os.path.join(output_root, "gold", "portfolio_dashboard.csv")
+    quality_report_path = os.path.join(output_root, "quality_report.json")
 
     raw_rows = read_csv(input_csv)
     bronze_rows = generate_bronze_tables(raw_rows)
@@ -29,5 +32,6 @@ def run_etl(input_csv: str, output_root: str) -> Paths:
     write_csv(silver_path, silver_rows)
     write_csv(gold_sponsor_path, gold_tables["sponsor_rollup"])
     write_csv(gold_dashboard_path, gold_tables["portfolio_dashboard"])
+    write_quality_report(quality_report_path, raw_rows)
 
-    return Paths(bronze=bronze_path, silver=silver_path, gold=os.path.dirname(gold_sponsor_path))
+    return Paths(bronze=bronze_path, silver=silver_path, gold=os.path.dirname(gold_sponsor_path), quality_report=quality_report_path)

--- a/etl-pipelines/exotic/data-centers/src/data_center_etl_pipeline/quality_report.py
+++ b/etl-pipelines/exotic/data-centers/src/data_center_etl_pipeline/quality_report.py
@@ -1,0 +1,98 @@
+import json
+import os
+from datetime import datetime
+from typing import Dict, List
+
+from .constants import NUMERIC_FIELDS
+
+CRITICAL_FIELDS = [
+    "facility_id",
+    "sponsor",
+    "country",
+    "report_date",
+    "gross_revenue_eur",
+    "debt_service_eur",
+    "market_value_eur",
+]
+
+
+def _is_missing(value: object) -> bool:
+    return value is None or str(value).strip() == ""
+
+
+def _is_invalid_date(value: object) -> bool:
+    if _is_missing(value):
+        return True
+    try:
+        datetime.strptime(str(value).strip(), "%Y-%m-%d")
+        return False
+    except ValueError:
+        return True
+
+
+def _is_invalid_numeric(value: object) -> bool:
+    if _is_missing(value):
+        return True
+    try:
+        float(str(value).strip())
+        return False
+    except ValueError:
+        return True
+
+
+def _is_suspicious_numeric(field: str, value: object) -> bool:
+    if _is_invalid_numeric(value):
+        return False
+
+    numeric_value = float(str(value).strip())
+    if field in {"it_load_mw", "leased_capacity_mw", "debt_service_eur", "market_value_eur", "gross_revenue_eur"}:
+        return numeric_value < 0
+    if field == "occupancy_pct":
+        return numeric_value < 0 or numeric_value > 100
+    return False
+
+
+def build_quality_report(rows: List[Dict[str, object]]) -> Dict[str, float | int]:
+    row_count = len(rows)
+
+    missing_key_identifiers = sum(1 for row in rows if _is_missing(row.get("facility_id")))
+    missing_critical_fields = sum(1 for row in rows if any(_is_missing(row.get(field)) for field in CRITICAL_FIELDS))
+    invalid_dates = sum(1 for row in rows if _is_invalid_date(row.get("report_date")))
+
+    invalid_numeric_values = 0
+    suspicious_values = 0
+    for row in rows:
+        for field in NUMERIC_FIELDS:
+            value = row.get(field)
+            if _is_invalid_numeric(value):
+                invalid_numeric_values += 1
+            if _is_suspicious_numeric(field, value):
+                suspicious_values += 1
+
+    denominator = max(row_count, 1)
+    penalty = (
+        missing_key_identifiers
+        + missing_critical_fields
+        + invalid_dates
+        + invalid_numeric_values
+        + suspicious_values
+    ) / denominator
+    overall_quality_score = round(max(0.0, 100.0 - penalty * 10.0), 2)
+
+    return {
+        "row_count": row_count,
+        "missing_key_identifiers": missing_key_identifiers,
+        "missing_critical_fields": missing_critical_fields,
+        "invalid_dates": invalid_dates,
+        "invalid_numeric_values": invalid_numeric_values,
+        "suspicious_values": suspicious_values,
+        "overall_quality_score": overall_quality_score,
+    }
+
+
+def write_quality_report(path: str, rows: List[Dict[str, object]]) -> Dict[str, float | int]:
+    report = build_quality_report(rows)
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(report, f, indent=2)
+    return report

--- a/etl-pipelines/exotic/data-centers/tests/test_quality_report.py
+++ b/etl-pipelines/exotic/data-centers/tests/test_quality_report.py
@@ -1,0 +1,48 @@
+import csv
+import json
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from data_center_etl_pipeline.pipeline import run_etl
+
+
+def _write_csv(path: Path, rows: list[dict[str, str]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=list(rows[0].keys()))
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def test_run_etl_generates_quality_report(tmp_path: Path) -> None:
+    rows = [
+        {"facility_id": "dc-001", "sponsor": "Alpha", "country": "DE", "report_date": "2026-03-01", "gross_revenue_eur": "100", "energy_cost_eur": "20", "opex_eur": "10", "debt_service_eur": "30", "market_value_eur": "500", "outstanding_debt_eur": "300", "it_load_mw": "10", "leased_capacity_mw": "8"},
+        {"facility_id": "", "sponsor": "Beta", "country": "FR", "report_date": "03/01/2026", "gross_revenue_eur": "-90", "energy_cost_eur": "abc", "opex_eur": "10", "debt_service_eur": "20", "market_value_eur": "100", "outstanding_debt_eur": "50", "it_load_mw": "-1", "leased_capacity_mw": "0"},
+    ]
+
+    input_csv = tmp_path / "input.csv"
+    output_root = tmp_path / "output"
+    _write_csv(input_csv, rows)
+
+    paths = run_etl(str(input_csv), str(output_root))
+
+    report_path = Path(paths.quality_report)
+    assert report_path.exists()
+
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    assert set(report.keys()) == {
+        "row_count",
+        "missing_key_identifiers",
+        "missing_critical_fields",
+        "invalid_dates",
+        "invalid_numeric_values",
+        "suspicious_values",
+        "overall_quality_score",
+    }
+    assert report["row_count"] == 2
+    assert report["missing_key_identifiers"] == 1
+    assert report["invalid_dates"] == 1
+    assert report["invalid_numeric_values"] >= 1
+    assert report["suspicious_values"] >= 1


### PR DESCRIPTION
### Motivation
- Provide a standardized, machine-readable data quality artifact (`quality_report.json`) for the data-center ETL so downstream tools and CI can evaluate input dataset health.
- Surface common quality signals (missing identifiers, invalid dates/numeric values, suspicious numeric ranges) alongside existing bronze/silver/gold outputs to simplify validation and monitoring.
- Ensure the pipeline emits this artifact during a full run and that its presence and schema are covered by automated tests.

### Description
- Add a new module `etl-pipelines/exotic/data-centers/src/data_center_etl_pipeline/quality_report.py` implementing `build_quality_report` and `write_quality_report` with rules for missing fields, invalid dates/numeric values, suspicious numeric checks, and an `overall_quality_score`.
- Wire report emission into the pipeline by updating `run_etl` in `etl-pipelines/exotic/data-centers/src/data_center_etl_pipeline/pipeline.py` to call `write_quality_report`, add `quality_report` to the returned `Paths` dataclass, and write the artifact at `<output_root>/quality_report.json`.
- Update the top-level ETL runner `etl-pipelines/exotic/data-centers/src/data_center_etl.py` to print the quality report path when running the full pipeline.
- Add an automated test `etl-pipelines/exotic/data-centers/tests/test_quality_report.py` that executes `run_etl` on a small mixed-validity sample CSV and validates the report file and expected keys/metrics.

### Testing
- Ran the new pipeline test with `pytest -q etl-pipelines/exotic/data-centers/tests/test_quality_report.py` and it passed (`1 passed`).
- The test verifies the `quality_report.json` exists and contains the keys `row_count`, `missing_key_identifiers`, `missing_critical_fields`, `invalid_dates`, `invalid_numeric_values`, `suspicious_values`, and `overall_quality_score`.
- The test asserts basic numeric expectations on the generated metrics for a sample of mixed-validity rows and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f81e4ba7088329882b34e0dbe30ac9)