### PR TITLE
Add CRE critical-field validation and aggregated validation summary

### DIFF
--- a/etl-pipelines/ESMA-Loan-level-data-templates/commercial-real-estate/src/cre_etl_pipeline/pipeline.py
+++ b/etl-pipelines/ESMA-Loan-level-data-templates/commercial-real-estate/src/cre_etl_pipeline/pipeline.py
@@ -37,6 +37,13 @@ def transform_underlying_exposures(
 
     output_rows: list[dict[str, Any]] = []
     missing_required = 0
+    validation_rule_counts = {
+        "negative_current_balance": 0,
+        "occupancy_out_of_range": 0,
+        "missing_loan_id": 0,
+        "non_numeric_dscr": 0,
+    }
+    valid_record_count = 0
 
     with Path(input_csv).open("r", encoding="utf-8", newline="") as handle:
         reader = csv.DictReader(handle)
@@ -52,11 +59,31 @@ def transform_underlying_exposures(
             if row.get("CREL1") is None or row.get("CREL4") is None:
                 missing_required += 1
 
+            loan_id = row.get("CREL5") or row.get("CREL4")
+            failed_rules: list[str] = []
+
+            if balance is not None and balance < 0:
+                failed_rules.append("negative_current_balance")
+            if occupancy is not None and (occupancy < 0 or occupancy > 100):
+                failed_rules.append("occupancy_out_of_range")
+            if loan_id is None:
+                failed_rules.append("missing_loan_id")
+            raw_dscr = row.get("CREL44")
+            if raw_dscr is not None and dscr is None:
+                failed_rules.append("non_numeric_dscr")
+
+            for rule in failed_rules:
+                validation_rule_counts[rule] += 1
+
+            is_valid = len(failed_rules) == 0
+            if is_valid:
+                valid_record_count += 1
+
             output_rows.append(
                 {
                     "deal_id": row.get("CREL1"),
                     "obligor_id": row.get("CREL3") or row.get("CREL2"),
-                    "loan_id": row.get("CREL5") or row.get("CREL4"),
+                    "loan_id": loan_id,
                     "property_type": row.get("CREL26"),
                     "country": row.get("CREL19"),
                     "current_balance": balance,
@@ -65,6 +92,7 @@ def transform_underlying_exposures(
                     "occupancy_rate": occupancy,
                     "default_status": row.get("CREL68"),
                     "special_servicing": row.get("CREL71"),
+                    "validation": {"is_valid": is_valid, "failed_rules": failed_rules},
                     "raw": row,
                 }
             )
@@ -75,6 +103,11 @@ def transform_underlying_exposures(
         "record_count": len(output_rows),
         "quality": {
             "rows_missing_primary_identifiers": missing_required,
+            "validation_summary": {
+                "valid_record_count": valid_record_count,
+                "invalid_record_count": len(output_rows) - valid_record_count,
+                "rule_failures": validation_rule_counts,
+            },
         },
         "records": output_rows,
     }

--- a/etl-pipelines/ESMA-Loan-level-data-templates/commercial-real-estate/tests/test_cre_validation.py
+++ b/etl-pipelines/ESMA-Loan-level-data-templates/commercial-real-estate/tests/test_cre_validation.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+
+from cre_etl_pipeline import pipeline
+from cre_etl_pipeline.taxonomy import TaxonomyField
+
+
+def _write_csv(path: Path, rows: list[dict[str, str]]) -> None:
+    fieldnames = [
+        "CREL1",
+        "CREL2",
+        "CREL3",
+        "CREL4",
+        "CREL5",
+        "CREL19",
+        "CREL26",
+        "CREL32",
+        "CREL40",
+        "CREL41",
+        "CREL44",
+        "CREL59",
+        "CREL68",
+        "CREL71",
+    ]
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row)
+
+
+def test_cre_validation_summary_and_rule_flags(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        pipeline,
+        "load_cre_taxonomy",
+        lambda _path: [TaxonomyField("sec", code, "n", "c", "f") for code in [
+            "CREL1", "CREL2", "CREL3", "CREL4", "CREL5", "CREL19", "CREL26", "CREL32", "CREL40", "CREL41", "CREL44", "CREL59", "CREL68", "CREL71"
+        ]],
+    )
+
+    input_csv = tmp_path / "input.csv"
+    output_json = tmp_path / "output.json"
+    _write_csv(
+        input_csv,
+        [
+            {
+                "CREL1": "deal-a",
+                "CREL4": "loan-a",
+                "CREL5": "loan-a",
+                "CREL32": "1500000",
+                "CREL41": "1000000",
+                "CREL44": "1.4",
+                "CREL59": "95",
+            },
+            {
+                "CREL1": "deal-b",
+                "CREL4": "loan-b",
+                "CREL32": "1000000",
+                "CREL41": "-500",
+                "CREL44": "abc",
+                "CREL59": "120",
+            },
+            {
+                "CREL1": "deal-c",
+                "CREL4": "",
+                "CREL5": "",
+                "CREL41": "500",
+                "CREL44": "1.1",
+                "CREL59": "50",
+            },
+        ],
+    )
+
+    result = pipeline.transform_underlying_exposures(
+        input_csv=input_csv,
+        taxonomy_xlsx="unused.xlsx",
+        output_json=output_json,
+        dl_code="CRE-TEST-1",
+    )
+
+    summary = result["quality"]["validation_summary"]
+    assert summary["valid_record_count"] == 1
+    assert summary["invalid_record_count"] == 2
+    assert summary["rule_failures"]["negative_current_balance"] == 1
+    assert summary["rule_failures"]["occupancy_out_of_range"] == 1
+    assert summary["rule_failures"]["missing_loan_id"] == 1
+    assert summary["rule_failures"]["non_numeric_dscr"] == 1
+
+    records = result["records"]
+    assert records[0]["validation"]["is_valid"] is True
+    assert records[1]["validation"]["is_valid"] is False
+    assert records[2]["validation"]["is_valid"] is False
+
+    persisted = json.loads(output_json.read_text(encoding="utf-8"))
+    assert persisted["quality"]["validation_summary"]["invalid_record_count"] == 2


### PR DESCRIPTION
### Motivation
- Surface common data quality issues in the CRE ETL pipeline before emitting normalized records so downstream consumers can filter or flag problematic rows.  
- Provide both per-record validation metadata and an aggregated observability summary to aid debugging and monitoring of incoming Annex 3 CRE datasets.

### Description
- Add rule checks in `transform_underlying_exposures` for `negative_current_balance`, `occupancy_out_of_range`, `missing_loan_id`, and `non_numeric_dscr` and count occurrences in `validation_rule_counts`.  
- Emit per-record `validation` metadata (`is_valid`, `failed_rules`) and compute `valid_record_count` for each run.  
- Add `validation_summary` to the payload `quality` section containing `valid_record_count`, `invalid_record_count`, and `rule_failures`.  
- Add unit test `etl-pipelines/ESMA-Loan-level-data-templates/commercial-real-estate/tests/test_cre_validation.py` which exercises mixed valid/invalid rows and asserts per-record flags and persisted summary.

### Testing
- Ran the focused test suite with `PYTHONPATH=etl-pipelines/ESMA-Loan-level-data-templates/commercial-real-estate/src pytest -q etl-pipelines/ESMA-Loan-level-data-templates/commercial-real-estate/tests/test_cre_validation.py`, which passed (`1 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f97ed9cf2c83299e20576e7204111d)