### PR TITLE
Add API endpoint for ETL quality summaries

### DIFF
--- a/api/api-backend-main/backend/app/routes/__init__.py
+++ b/api/api-backend-main/backend/app/routes/__init__.py
@@ -7,6 +7,7 @@ from app.config import API_VERSION as version
 # from app.routes.les import router as les_router
 # from app.routes.rmb import router as rmb_router
 from app.routes.sme import router as sme_router
+from app.routes.etl import router as etl_router
 
 router = HandleTrailingSlashRouter()
 
@@ -16,3 +17,4 @@ router = HandleTrailingSlashRouter()
 # router.include_router(les_router, prefix=f"/api/{version}/les")
 # router.include_router(rmb_router, prefix=f"/api/{version}/rmb")
 router.include_router(sme_router, prefix=f"/api/{version}/sme")
+router.include_router(etl_router, prefix=f"/api/{version}/etl")

--- a/api/api-backend-main/backend/app/routes/etl.py
+++ b/api/api-backend-main/backend/app/routes/etl.py
@@ -1,0 +1,34 @@
+from typing import Optional
+
+from fastapi import APIRouter, Header, HTTPException
+
+from app import big_query_useful as useful
+
+router = APIRouter()
+
+
+@router.get("/quality-summaries", tags=["etl"], name="etl_quality_summaries")
+async def get_etl_quality_summaries(
+    limit: int = None,
+    offset: int = None,
+    detailed: bool = True,
+    x_algoritmica_api_key: Optional[str] = Header(None),  # needed for swagger
+):
+    try:
+        params = dict(
+            credit_type="sme",
+            table_name="quality_summaries",
+            filters=None,
+            limit=limit,
+            offset=offset,
+            columns=None,
+        )
+
+        result = (
+            await useful.query_to_list_of_dicts(**params)
+            if detailed
+            else await useful.query_to_list_of_lists(**params)
+        )
+        return result
+    except Exception as ex:
+        raise HTTPException(status_code=400, detail=str(ex))

--- a/api/api-backend-main/backend/tests/test_sme_endpoints.py
+++ b/api/api-backend-main/backend/tests/test_sme_endpoints.py
@@ -140,3 +140,34 @@ class TestSmeEndpointsWithMockedBQ:
             params={"filter": "BADCOLUMN:val"},
         )
         assert resp.status_code == 400
+
+
+class TestEtlQualitySummariesEndpoint:
+    """Tests for the ETL quality summaries endpoint."""
+
+    def test_etl_quality_summaries_route_exists(self, test_client, auth_header):
+        resp = test_client.get("/api/v1/etl/quality-summaries", headers=auth_header)
+        assert resp.status_code != 404
+
+    def test_etl_quality_summaries_returns_mocked_data(
+        self, test_client, auth_header, mock_bigquery_dicts,
+    ):
+        resp = test_client.get("/api/v1/etl/quality-summaries", headers=auth_header)
+        assert resp.status_code == 200
+        data = resp.json()
+        assert isinstance(data, list)
+        assert data[0]["dl_code"] == "TEST001"
+
+    def test_etl_quality_summaries_uses_expected_query_params(
+        self, test_client, auth_header, mock_bigquery_dicts,
+    ):
+        test_client.get(
+            "/api/v1/etl/quality-summaries",
+            headers=auth_header,
+            params={"limit": 7, "offset": 3},
+        )
+        call_kwargs = mock_bigquery_dicts.call_args.kwargs
+        assert call_kwargs["credit_type"] == "sme"
+        assert call_kwargs["table_name"] == "quality_summaries"
+        assert call_kwargs["limit"] == 7
+        assert call_kwargs["offset"] == 3


### PR DESCRIPTION
### Motivation
- Expose ETL/data-quality summary rows through the API so frontends and tools can fetch ETL quality profiles programmatically.
- Reuse existing BigQuery query helpers to avoid duplicating SQL/serialization logic for quality data.

### Description
- Add a new FastAPI route module `app/routes/etl.py` that registers `GET /quality-summaries` and accepts `limit`, `offset`, and `detailed` query params; the route calls `big_query_useful.query_to_list_of_dicts` or `query_to_list_of_lists` depending on `detailed`.
- Wire the ETL router into the main router registry by including `etl_router` under the `/api/v1/etl` prefix in `app/routes/__init__.py`.
- Add integration tests in `api/.../tests/test_sme_endpoints.py` to assert route registration, mocked-response behavior, and that query parameters are forwarded (expects `credit_type="sme"` and `table_name="quality_summaries"`).

### Testing
- Ran: `cd api/api-backend-main/backend && pytest tests/test_sme_endpoints.py -q` which attempted to exercise the new endpoint and existing SME endpoint tests.
- Result: tests could not complete in this environment due to missing dependency (`ModuleNotFoundError: No module named 'pymongo'`) during test app startup, producing multiple errors (16 errors, 1 warning) rather than failures in the new endpoint logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f9831935448329a88ba2d0e7804dc5)