### PR TITLE
Add runnable end-to-end ETL sample with validation output

### DIFF
--- a/etl-pipelines/exotic/data-centers/readme.md
+++ b/etl-pipelines/exotic/data-centers/readme.md
@@ -35,3 +35,27 @@ python src/data_center_etl.py --input sample_data/raw_facilities.csv --output ou
 python src/data_center_etl.py --input sample_data/raw_facilities.csv --output output --stage-name silver
 python src/data_center_etl.py --input sample_data/raw_facilities.csv --output output --stage-name gold
 ```
+
+## End-to-end sample (raw CSV -> API-ready JSON + validation report)
+
+Run one command to execute the full ETL and generate normalized JSON with a validation report:
+
+```bash
+cd etl-pipelines/exotic/data-centers
+python src/run_e2e_sample.py
+```
+
+Generated artifacts:
+
+- `output/bronze/facility_bronze.csv`
+- `output/silver/facility_silver.csv`
+- `output/gold/sponsor_rollup.csv`
+- `output/gold/portfolio_dashboard.csv`
+- `output/normalized/facility_normalized.json` (API-ready normalized payload)
+- `output/reports/validation_report.json` (schema/quality checks summary)
+
+Run tests for the sample:
+
+```bash
+pytest etl-pipelines/exotic/data-centers/tests/test_e2e_sample.py
+```

--- a/etl-pipelines/exotic/data-centers/src/run_e2e_sample.py
+++ b/etl-pipelines/exotic/data-centers/src/run_e2e_sample.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Runnable end-to-end sample: raw CSV -> normalized JSON + validation report."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from typing import Dict, List, Tuple
+
+from data_center_etl_pipeline.pipeline import run_etl
+from data_center_etl_pipeline.io import read_csv
+
+REQUIRED_FIELDS = [
+    "facility_id",
+    "sponsor",
+    "country",
+    "report_date",
+    "noi_eur",
+    "dscr",
+    "ltv_pct",
+    "occupancy_pct",
+    "energy_cost_ratio_pct",
+    "junior_note_watch_status",
+]
+
+
+def _validate_rows(rows: List[Dict[str, object]]) -> Tuple[bool, Dict[str, object]]:
+    missing_required = []
+    for idx, row in enumerate(rows):
+        missing = [field for field in REQUIRED_FIELDS if field not in row or row[field] in ("", None)]
+        if missing:
+            missing_required.append({"row_index": idx, "missing_fields": missing})
+
+    allowed_status = {"ok", "watch", "breach"}
+    bad_status_rows = [
+        {"row_index": idx, "status": row.get("junior_note_watch_status")}
+        for idx, row in enumerate(rows)
+        if row.get("junior_note_watch_status") not in allowed_status
+    ]
+
+    report = {
+        "is_valid": not missing_required and not bad_status_rows,
+        "row_count": len(rows),
+        "required_fields": REQUIRED_FIELDS,
+        "missing_required": missing_required,
+        "invalid_status_rows": bad_status_rows,
+    }
+    return report["is_valid"], report
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run end-to-end data-center ETL sample")
+    parser.add_argument("--input", default="sample_data/raw_facilities.csv", help="Raw input CSV path")
+    parser.add_argument("--output", default="output", help="Output root path")
+    args = parser.parse_args()
+
+    paths = run_etl(args.input, args.output)
+    silver_rows = read_csv(paths.silver)
+
+    normalized_json_path = os.path.join(args.output, "normalized", "facility_normalized.json")
+    validation_report_path = os.path.join(args.output, "reports", "validation_report.json")
+    os.makedirs(os.path.dirname(normalized_json_path), exist_ok=True)
+    os.makedirs(os.path.dirname(validation_report_path), exist_ok=True)
+
+    with open(normalized_json_path, "w", encoding="utf-8") as f:
+        json.dump(silver_rows, f, indent=2)
+
+    is_valid, report = _validate_rows(silver_rows)
+    report["artifacts"] = {
+        "bronze_csv": paths.bronze,
+        "silver_csv": paths.silver,
+        "gold_dir": paths.gold,
+        "normalized_json": normalized_json_path,
+    }
+
+    with open(validation_report_path, "w", encoding="utf-8") as f:
+        json.dump(report, f, indent=2)
+
+    print(f"Bronze: {paths.bronze}")
+    print(f"Silver: {paths.silver}")
+    print(f"Gold:   {paths.gold}")
+    print(f"Normalized JSON: {normalized_json_path}")
+    print(f"Validation report: {validation_report_path}")
+    print(f"Validation status: {'PASS' if is_valid else 'FAIL'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/etl-pipelines/exotic/data-centers/tests/test_e2e_sample.py
+++ b/etl-pipelines/exotic/data-centers/tests/test_e2e_sample.py
@@ -1,0 +1,34 @@
+import json
+import subprocess
+from pathlib import Path
+
+
+def test_e2e_sample_generates_artifacts_and_valid_report(tmp_path: Path):
+    base_dir = Path(__file__).resolve().parents[1]
+    output_dir = tmp_path / "output"
+
+    cmd = [
+        "python",
+        str(base_dir / "src" / "run_e2e_sample.py"),
+        "--input",
+        str(base_dir / "sample_data" / "raw_facilities.csv"),
+        "--output",
+        str(output_dir),
+    ]
+    result = subprocess.run(cmd, cwd=base_dir, capture_output=True, text=True, check=True)
+
+    normalized_json = output_dir / "normalized" / "facility_normalized.json"
+    report_json = output_dir / "reports" / "validation_report.json"
+
+    assert normalized_json.exists(), result.stdout
+    assert report_json.exists(), result.stdout
+
+    rows = json.loads(normalized_json.read_text(encoding="utf-8"))
+    report = json.loads(report_json.read_text(encoding="utf-8"))
+
+    assert isinstance(rows, list)
+    assert len(rows) > 0
+    assert report["is_valid"] is True
+    assert report["row_count"] == len(rows)
+    assert report["missing_required"] == []
+    assert report["invalid_status_rows"] == []


### PR DESCRIPTION
### Motivation
- Provide a concrete, one-command end-to-end example for the Data Centers ETL so users can run the full medallion pipeline and obtain API-ready outputs quickly. 
- Add basic machine-readable validation so the normalized output can be automatically checked for required fields and status correctness.

### Description
- Add a runnable sample script at `etl-pipelines/exotic/data-centers/src/run_e2e_sample.py` that calls `run_etl`, writes normalized JSON to `output/normalized/facility_normalized.json`, and emits a validation report to `output/reports/validation_report.json`.
- Implement simple validation logic in the sample to check `REQUIRED_FIELDS` and ensure `junior_note_watch_status` is one of `ok|watch|breach`, and include artifact paths in the report.
- Update the Data Centers README `etl-pipelines/exotic/data-centers/readme.md` with a quickstart for the end-to-end sample and a list of generated artifacts.
- Add an integration-style test `etl-pipelines/exotic/data-centers/tests/test_e2e_sample.py` that runs the sample command and asserts artifact creation and validation pass conditions.

### Testing
- Ran the sample script with `python etl-pipelines/exotic/data-centers/src/run_e2e_sample.py --input etl-pipelines/exotic/data-centers/sample_data/raw_facilities.csv --output /tmp/deeploans-e2e-output` which produced the normalized JSON and validation report and printed `Validation status: PASS`.
- Executed `pytest -q etl-pipelines/exotic/data-centers/tests/test_e2e_sample.py` which returned `1 passed`.
- The CI-style integration test verifies the existence of `facility_normalized.json` and `validation_report.json` and asserts `report["is_valid"]` is `True`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f9cb24f4d88329997bdd881e2c0347)