### PR TITLE
Add schema contract tests for normalized ETL outputs

### DIFF
--- a/api/api-backend-main/backend/tests/normalized_output_contracts.py
+++ b/api/api-backend-main/backend/tests/normalized_output_contracts.py
@@ -1,0 +1,74 @@
+"""Schema contracts for normalized ETL outputs.
+
+The contracts in this module intentionally focus on stable downstream
+compatibility guarantees: required field presence and broad JSON-compatible
+basic types. They are small and declarative so additional asset classes or
+normalized outputs can be added without changing the validation test logic.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from numbers import Real
+from typing import Any, Mapping
+
+
+@dataclass(frozen=True)
+class FieldContract:
+    """Expected basic JSON type for a required normalized output field."""
+
+    json_type: str
+    nullable: bool = False
+
+
+@dataclass(frozen=True)
+class NormalizedOutputContract:
+    """Required-field contract for one normalized output dataset."""
+
+    asset_class: str
+    dataset_name: str
+    required_fields: Mapping[str, FieldContract]
+
+
+JSON_TYPE_NAMES = {"string", "number", "boolean", "object", "array"}
+
+
+DATA_CENTER_FACILITY_SILVER_CONTRACT = NormalizedOutputContract(
+    asset_class="data_centers",
+    dataset_name="facility_silver",
+    required_fields={
+        "facility_id": FieldContract("string"),
+        "sponsor": FieldContract("string"),
+        "country": FieldContract("string"),
+        "report_date": FieldContract("string"),
+        "noi_eur": FieldContract("number"),
+        "dscr": FieldContract("number"),
+        "ltv_pct": FieldContract("number"),
+        "occupancy_pct": FieldContract("number"),
+        "energy_cost_ratio_pct": FieldContract("number"),
+        "junior_note_watch_status": FieldContract("string"),
+    },
+)
+
+
+NORMALIZED_OUTPUT_CONTRACTS = (DATA_CENTER_FACILITY_SILVER_CONTRACT,)
+
+
+def matches_json_type(value: Any, expected_json_type: str) -> bool:
+    """Return whether a value matches a broad JSON-compatible basic type."""
+
+    if expected_json_type not in JSON_TYPE_NAMES:
+        raise ValueError(f"Unsupported JSON type in contract: {expected_json_type}")
+
+    if expected_json_type == "string":
+        return isinstance(value, str)
+    if expected_json_type == "number":
+        return isinstance(value, Real) and not isinstance(value, bool)
+    if expected_json_type == "boolean":
+        return isinstance(value, bool)
+    if expected_json_type == "object":
+        return isinstance(value, dict)
+    if expected_json_type == "array":
+        return isinstance(value, list)
+
+    return False

--- a/api/api-backend-main/backend/tests/test_normalized_output_contracts.py
+++ b/api/api-backend-main/backend/tests/test_normalized_output_contracts.py
@@ -1,0 +1,137 @@
+"""Contract tests for normalized loan-level ETL outputs."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+import pytest
+
+from tests.normalized_output_contracts import (
+    DATA_CENTER_FACILITY_SILVER_CONTRACT,
+    NORMALIZED_OUTPUT_CONTRACTS,
+    FieldContract,
+    NormalizedOutputContract,
+    matches_json_type,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+DATA_CENTER_PIPELINE_SRC = REPO_ROOT / "etl-pipelines" / "exotic" / "data-centers" / "src"
+sys.path.insert(0, str(DATA_CENTER_PIPELINE_SRC))
+
+from data_center_etl_pipeline.generate_asset_silver import generate_asset_silver  # noqa: E402
+from data_center_etl_pipeline.generate_bronze_tables import generate_bronze_tables  # noqa: E402
+from data_center_etl_pipeline.io import read_csv  # noqa: E402
+
+DATA_CENTER_SAMPLE_INPUT = (
+    REPO_ROOT / "etl-pipelines" / "exotic" / "data-centers" / "sample_data" / "raw_facilities.csv"
+)
+
+
+def _validate_record_contract(
+    record: Mapping[str, Any], contract: NormalizedOutputContract
+) -> list[str]:
+    """Validate one JSON-like normalized output record and return drift messages."""
+
+    failures: list[str] = []
+    for field_name, field_contract in contract.required_fields.items():
+        if field_name not in record:
+            failures.append(
+                f"{contract.asset_class}.{contract.dataset_name}: missing required field "
+                f"'{field_name}'"
+            )
+            continue
+
+        value = record[field_name]
+        if value is None:
+            if not field_contract.nullable:
+                failures.append(
+                    f"{contract.asset_class}.{contract.dataset_name}.{field_name}: "
+                    "expected non-null value"
+                )
+            continue
+
+        if not matches_json_type(value, field_contract.json_type):
+            failures.append(
+                f"{contract.asset_class}.{contract.dataset_name}.{field_name}: expected "
+                f"{field_contract.json_type}, got {type(value).__name__}"
+            )
+
+    return failures
+
+
+def assert_records_match_contract(
+    records: Sequence[Mapping[str, Any]], contract: NormalizedOutputContract
+) -> None:
+    """Assert every normalized output record satisfies its required schema contract."""
+
+    assert records, f"{contract.asset_class}.{contract.dataset_name}: no records to validate"
+
+    failures = []
+    for index, record in enumerate(records):
+        for failure in _validate_record_contract(record, contract):
+            failures.append(f"record {index}: {failure}")
+
+    assert not failures, "Normalized output schema contract drift detected:\n" + "\n".join(
+        failures
+    )
+
+
+def _generate_data_center_facility_silver_json_records() -> list[dict[str, Any]]:
+    raw_rows = read_csv(str(DATA_CENTER_SAMPLE_INPUT))
+    bronze_rows = generate_bronze_tables(raw_rows)
+    silver_rows = generate_asset_silver(bronze_rows)
+
+    # Contract tests validate the JSON shape exposed to downstream consumers,
+    # so force a JSON round trip to catch non-serializable values early.
+    return json.loads(json.dumps(silver_rows))
+
+
+@pytest.mark.parametrize("contract", NORMALIZED_OUTPUT_CONTRACTS)
+def test_contract_definitions_use_supported_basic_json_types(
+    contract: NormalizedOutputContract,
+) -> None:
+    for field_name, field_contract in contract.required_fields.items():
+        assert field_contract.json_type in {
+            "string",
+            "number",
+            "boolean",
+            "object",
+            "array",
+        }, f"{contract.asset_class}.{contract.dataset_name}.{field_name} has unsupported type"
+
+
+def test_data_center_facility_silver_normalized_json_matches_contract() -> None:
+    records = _generate_data_center_facility_silver_json_records()
+
+    assert_records_match_contract(records, DATA_CENTER_FACILITY_SILVER_CONTRACT)
+
+
+def test_contract_validation_reports_removed_required_field() -> None:
+    record = _generate_data_center_facility_silver_json_records()[0]
+    record.pop("facility_id")
+
+    failures = _validate_record_contract(record, DATA_CENTER_FACILITY_SILVER_CONTRACT)
+
+    assert any("missing required field 'facility_id'" in failure for failure in failures)
+
+
+def test_contract_validation_reports_incompatible_required_field_type() -> None:
+    record = _generate_data_center_facility_silver_json_records()[0]
+    record["dscr"] = "1.667"
+
+    failures = _validate_record_contract(record, DATA_CENTER_FACILITY_SILVER_CONTRACT)
+
+    assert any("facility_silver.dscr: expected number, got str" in failure for failure in failures)
+
+
+def test_nullable_contract_fields_allow_null_values() -> None:
+    contract = NormalizedOutputContract(
+        asset_class="example",
+        dataset_name="normalized_output",
+        required_fields={"optional_metric": FieldContract("number", nullable=True)},
+    )
+
+    assert _validate_record_contract({"optional_metric": None}, contract) == []


### PR DESCRIPTION
### Motivation
- Provide small, declarative schema contracts for normalized ETL outputs so downstream consumers have a stable, testable contract for required fields and basic JSON types.
- Detect schema drift in normalized outputs early by validating presence, nullability, and broad JSON-compatible typing of fields produced by ETL pipelines.

### Description
- Add `api/api-backend-main/backend/tests/normalized_output_contracts.py` which declares `FieldContract` and `NormalizedOutputContract`, a `DATA_CENTER_FACILITY_SILVER_CONTRACT`, and `matches_json_type` helper for broad JSON typing.
- Add `api/api-backend-main/backend/tests/test_normalized_output_contracts.py` which generates the data-center `facility_silver` output from sample ETL input, forces a JSON round-trip, and asserts required-field presence, type compatibility, nullable behavior, and clear drift messages for removed or incompatible fields.
- Tests import the local data-center pipeline sources via a `sys.path` insertion so the contract checks exercise the actual normalization logic.

### Testing
- Ran `pytest api/api-backend-main/backend/tests/test_normalized_output_contracts.py`, and the new contract tests passed (`5 passed`).
- Ran `python -m py_compile api/api-backend-main/backend/tests/normalized_output_contracts.py api/api-backend-main/backend/tests/test_normalized_output_contracts.py`, and compilation succeeded.
- Attempting to run the full repository test suite (`pytest` / `pytest api/api-backend-main/backend/tests`) in this environment exercised the new tests but was blocked by unrelated environment dependencies (missing `pymongo` and other local imports), causing existing SME/mcp-server tests to error; these failures are environmental and not caused by the added contract tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fadde0b8e883298ce851eb5a5f0482)