### PR TITLE
Add MCP-to-API smoke tests for local integration

### DIFF
--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -41,6 +41,16 @@ deeploans-mcp
 }
 ```
 
+## Testing
+
+Run the MCP server test suite from the repository root:
+
+```bash
+python -m pytest mcp-server/tests
+```
+
+The smoke tests spin up an in-process localhost HTTP server, so they do not require production credentials, a real Deeploans API key, or network access outside the local machine.
+
 ## Notes
 
 - API-calling tools expect the backend to be running (default: `http://localhost:8000`).

--- a/mcp-server/tests/test_api_smoke.py
+++ b/mcp-server/tests/test_api_smoke.py
@@ -1,0 +1,120 @@
+import json
+import sys
+import threading
+import unittest
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import parse_qs, urlparse
+
+sys.path.insert(0, "mcp-server")
+from deeploans_mcp import server
+
+
+class LocalDeeploansAPI:
+    def __init__(self):
+        self.requests = []
+        self._httpd = None
+        self._thread = None
+
+    def __enter__(self):
+        parent = self
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_GET(self):
+                parsed = urlparse(self.path)
+                parent.requests.append(
+                    {
+                        "path": parsed.path,
+                        "query": parse_qs(parsed.query),
+                        "headers": dict(self.headers),
+                    }
+                )
+
+                if parsed.path == "/openapi.json":
+                    self._send_json(
+                        {
+                            "openapi": "3.1.0",
+                            "info": {"title": "Local Deeploans Test API", "version": "test"},
+                            "paths": {"/api/v1/sme/loans": {"get": {}}},
+                        }
+                    )
+                    return
+
+                if parsed.path == "/api/v1/sme/loans":
+                    self._send_json(
+                        {
+                            "data": [
+                                {"loan_id": "loan-1", "principal_balance": 1000},
+                                {"loan_id": "loan-2", "principal_balance": 2500},
+                            ]
+                        }
+                    )
+                    return
+
+                if parsed.path == "/api/v1/sme/erroring_loans":
+                    self._send_json({"error": "backend unavailable"}, status=500)
+                    return
+
+                self._send_json({"error": "not found"}, status=404)
+
+            def log_message(self, format, *args):
+                pass
+
+            def _send_json(self, payload, status=200):
+                body = json.dumps(payload).encode("utf-8")
+                self.send_response(status)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+        self._httpd = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        self._thread = threading.Thread(target=self._httpd.serve_forever, daemon=True)
+        self._thread.start()
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self._httpd.shutdown()
+        self._httpd.server_close()
+        self._thread.join(timeout=2)
+
+    @property
+    def base_url(self):
+        host, port = self._httpd.server_address
+        return f"http://{host}:{port}"
+
+
+class TestMCPToAPISmoke(unittest.TestCase):
+    def test_fetch_api_docs_uses_configured_local_base_url(self):
+        with LocalDeeploansAPI() as api:
+            result = server.fetch_api_docs(base_url=api.base_url)
+
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["source"], "api")
+        self.assertEqual(result["title"], "Local Deeploans Test API")
+        self.assertEqual(result["url"], f"{api.base_url}/openapi.json")
+        self.assertEqual(api.requests[0]["path"], "/openapi.json")
+
+    def test_sample_rows_calls_configured_local_api_path_and_query(self):
+        with LocalDeeploansAPI() as api:
+            result = server.sample_rows("sme", "loans", limit=2, base_url=api.base_url)
+
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["url"], f"{api.base_url}/api/v1/sme/loans?limit=2&offset=0")
+        self.assertEqual(result["row_count"], 2)
+        self.assertEqual(result["sample"][0]["loan_id"], "loan-1")
+        self.assertEqual(api.requests[-1]["path"], "/api/v1/sme/loans")
+        self.assertEqual(api.requests[-1]["query"], {"limit": ["2"], "offset": ["0"]})
+
+    def test_sample_rows_preserves_http_error_url_and_details(self):
+        with LocalDeeploansAPI() as api:
+            result = server.sample_rows("sme", "erroring_loans", limit=2, base_url=api.base_url)
+
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["url"], f"{api.base_url}/api/v1/sme/erroring_loans?limit=2&offset=0")
+        self.assertEqual(result["error"], "HTTP 500")
+        self.assertIn("backend unavailable", result["details"])
+        self.assertEqual(api.requests[-1]["path"], "/api/v1/sme/erroring_loans")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Provide deterministic integration-level coverage that MCP tools correctly call a running API and handle success and HTTP error responses.
- Make it easy for contributors to run these checks locally without requiring production credentials or external network access.

### Description
- Add `mcp-server/tests/test_api_smoke.py`, which spins up an in-process HTTP server and asserts `fetch_api_docs` uses the configured `base_url`, `sample_rows` requests `/api/v1/sme/loans?limit=2&offset=0`, and HTTP 500 responses preserve URL and details.
- Tests capture requested paths, query parameters, and headers to verify request shape and response handling.
- Update `mcp-server/README.md` with a `## Testing` section documenting how to run the MCP test suite using `python -m pytest mcp-server/tests`.

### Testing
- Ran the MCP server test suite with `python -m pytest mcp-server/tests -q` and the suite completed successfully with `8 passed`.
- The smoke tests run against the local in-process HTTP server, so they do not require a real Deeploans API key or external network access.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fc2a3f32288329a6429b8f64f170ce)