### PR TITLE
synthetic-data-designer: fix the install command in the app

### DIFF
--- a/synthetic-data-designer/src/sdd/cli.py
+++ b/synthetic-data-designer/src/sdd/cli.py
@@ -58,7 +58,7 @@ def ui(
         from sdd.web.app import serve
     except ImportError as exc:
         typer.secho(
-            "the web UI needs a couple of extra packages:\n  pip install 'sdd[web]'",
+            "the web UI needs a couple of extra packages:\n  pip install -e '.[web]'",
             fg=typer.colors.RED,
         )
         raise typer.Exit(1) from exc

--- a/synthetic-data-designer/src/sdd/generate/backend_nemo.py
+++ b/synthetic-data-designer/src/sdd/generate/backend_nemo.py
@@ -8,7 +8,7 @@ outputs, embeddings) alongside the samplers.
 
 Enable with::
 
-    pip install 'sdd[nemo]'
+    pip install -e '.[nemo]'
     sdd run <spec> --backend nemo
 
 The contract is identical either way: same spec in, same columns out. Only the
@@ -56,7 +56,7 @@ def _require_nemo() -> tuple[Any, Any]:
     except ImportError as exc:  # pragma: no cover - depends on the extra
         raise NemoUnavailable(
             "the 'nemo' backend needs NVIDIA NeMo Data Designer, which is not installed.\n"
-            "  pip install 'sdd[nemo]'\n"
+            "  pip install -e '.[nemo]'\n"
             "The default numpy backend needs no extra dependencies and produces the "
             "same columns."
         ) from exc

--- a/synthetic-data-designer/src/sdd/polish/ctgan.py
+++ b/synthetic-data-designer/src/sdd/polish/ctgan.py
@@ -23,7 +23,7 @@ switched off.
 
 Enable with::
 
-    pip install 'sdd[deep]'
+    pip install -e '.[deep]'
 """
 
 from __future__ import annotations
@@ -50,7 +50,7 @@ def _require_sdv() -> Any:
     except ImportError as exc:  # pragma: no cover - depends on the extra
         raise DeepUnavailable(
             "the deep polish step needs SDV, which is not installed.\n"
-            "  pip install 'sdd[deep]'\n"
+            "  pip install -e '.[deep]'\n"
             "Generation works without it; the polish step only refines an existing sample."
         ) from exc
     import sdv

--- a/synthetic-data-designer/src/sdd/web/static/app.js
+++ b/synthetic-data-designer/src/sdd/web/static/app.js
@@ -17,6 +17,11 @@
 
 const VIEWS = ["upload", "review", "configure", "generate", "results", "download"];
 
+// Where the code lives. Referenced from the shared-instance notice, which tells
+// a visitor how to run this privately and therefore has to say where to get it.
+const SOURCE_URL =
+  "https://github.com/Algoritmica-ai/deeploans/tree/main/synthetic-data-designer";
+
 const state = {
   view: "upload",
   source: null,          // token tying the uploaded schema + sample together
@@ -395,8 +400,10 @@ function describeInstance(meta) {
     "restarts, so download what you generate before you leave." +
     (bounds.length ? ` Limited to ${bounds.join(", ")}.` : "") +
     "<br><br>Do not upload confidential data. To use your own tapes privately, run it on " +
-    "your own machine: <code class=\"inline\">pip install 'sdd[web]'</code> then " +
-    "<code class=\"inline\">sdd ui</code> — then nothing leaves it.",
+    "your own machine — clone the repository, then " +
+    "<code class=\"inline\">pip install -e '.[web]'</code> and " +
+    "<code class=\"inline\">sdd ui</code>. Nothing leaves it. " +
+    `<a href="${SOURCE_URL}" target="_blank" rel="noopener noreferrer">Source</a>.`,
     "warn", true));
 }
 
@@ -894,7 +901,7 @@ function renderMethods() {
       el("div", { class: "m-desc", text: description }),
       blocked ? el("div", { class: "m-need", text:
         needsDeep && needsSample ? `Unavailable — ${requirement}.`
-        : needsDeep ? "Unavailable — install the deep extra: pip install 'sdd[deep]'."
+        : needsDeep ? "Unavailable — install the deep extra: pip install -e '.[deep]'."
         : "Unavailable — upload sample data in step 1." }) : null,
     ]));
   }

--- a/synthetic-data-designer/src/sdd/web/static/index.html
+++ b/synthetic-data-designer/src/sdd/web/static/index.html
@@ -103,8 +103,9 @@
         <div class="card-head">
           <h2>Or start from a calibrated pack</h2>
         </div>
-        <p class="hint">A pack is a spec already calibrated against a real asset class. Load one
-           to skip straight to configuring.</p>
+        <p class="hint">A ready-made spec you can load and run without uploading anything.
+           Most are calibrated against a real asset class; the first is built so the best
+           score any model could achieve on it is computable.</p>
         <div class="pack-list" id="packs"></div>
       </div>
 

--- a/synthetic-data-designer/tests/test_api.py
+++ b/synthetic-data-designer/tests/test_api.py
@@ -296,7 +296,9 @@ def test_the_nemo_backend_explains_how_to_install_it():
 
     from sdd.generate.backend_nemo import NemoUnavailable, sample_columns_nemo
 
-    with pytest.raises(NemoUnavailable, match=r"pip install 'sdd\[nemo\]'"):
+    # Same reason as the deep extra below: the command in the message has to be
+    # one that works, and `sdd` on PyPI is an unrelated package.
+    with pytest.raises(NemoUnavailable, match=r"pip install -e '\.\[nemo\]'"):
         sample_columns_nemo(api.load(PACK), 10)
 
 
@@ -312,5 +314,41 @@ def test_the_deep_polish_explains_how_to_install_it():
 
     from sdd.polish import DeepUnavailable, polish_book
 
-    with pytest.raises(DeepUnavailable, match=r"pip install 'sdd\[deep\]'"):
+    # The command has to be one that works. `sdd` on PyPI is an unrelated
+    # video-detection library, so the old message sent a stuck user to install
+    # someone else's package.
+    with pytest.raises(DeepUnavailable, match=r"pip install -e '\.\[deep\]'"):
         polish_book(pd.DataFrame({"a": [1]}), api.load(PACK), seed_data=pd.DataFrame({"a": [1]}))
+
+
+def test_no_install_instruction_names_the_taken_package():
+    """`pip install sdd` fetches somebody else's library.
+
+    `sdd` on PyPI is an unrelated video-detection package, so any instruction
+    naming it sends a user to install the wrong thing. The import name is still
+    `sdd`; the *distribution* is `synthetic-data-designer`.
+
+    Checked by reading the source rather than by triggering each message,
+    because the two tests that do trigger them **skip whenever the optional
+    package happens to be installed** — which is why the NeMo message survived
+    a sweep, passed locally, and failed on all three CI versions. A test that
+    only runs in some environments cannot guard a string that appears in all of
+    them.
+    """
+    import re
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parents[1]
+    pattern = re.compile(r"""pip install\s+['"]?sdd\[""")
+
+    offenders = []
+    for path in list(root.rglob("*.py")) + list(root.rglob("*.js")) + list(root.rglob("*.md")):
+        if any(part in (".git", ".venv", "node_modules", "__pycache__") for part in path.parts):
+            continue
+        if pattern.search(path.read_text(encoding="utf-8", errors="ignore")):
+            offenders.append(str(path.relative_to(root)))
+
+    assert not offenders, (
+        f"these tell a user to install the wrong package: {offenders}. "
+        "Use `pip install -e '.[extra]'`, which installs this checkout."
+    )


### PR DESCRIPTION
Follow-up to #88. Six files.

## The bug

`pip install 'sdd[web]'` **installs an unrelated video-detection library** — `sdd` is taken on PyPI:

```
sdd 0.2.2.7 — "lightweight video detection"
```

It also means this project can never be published under that name; the distribution is `synthetic-data-designer` and the import name stays `sdd`.

The docs were corrected before the import landed. **The application still carried its own copies** — and five of the seven were *error messages*, read at the moment a user is already stuck:

| where | |
|---|---|
| shared-instance notice | how to run privately — the one place a privacy warning must be actionable |
| CLI | `sdd ui` without the web extra |
| CTGAN polish | ×2 |
| NeMo backend | ×2 |
| method picker | "install the deep extra" |

All now `pip install -e '.[web]'`, which installs the checkout and is what works today. The notice also links to the source, having previously told people to clone a repository without saying which.

## The durable part

A new check reads the source for the broken string and fails with the offending paths.

Worth explaining why that is needed rather than just fixing the strings: the two tests that *trigger* these messages **skip whenever the optional package is installed**. On a machine with NeMo present, that test never runs — which is exactly how the NeMo message survived a sweep, passed locally, and failed on all three CI versions. The new check runs in every environment and covers files no test exercises.

Confirmed it can fail, by reintroducing the string and watching it fire.

## Also

The pack blurb predated the benchmark pack and claimed every pack is calibrated against a real asset class. The first one is not — it is built so the best achievable score is computable.

**712 tests pass, run from inside this repository.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
