### PR TITLE
Add Deeploans OS components diagram to Credit FM README

### DIFF
--- a/credit-foundation-model/README.md
+++ b/credit-foundation-model/README.md
@@ -89,6 +89,8 @@ Start with the data bible: [`notebooks/00_data_bible.ipynb`](notebooks/00_data_b
 
 ## What's in here
 
+![Deeploans OS components](../Deeploans%20OS%20components.svg)
+
 | Component | Location | Description |
 |-----------|----------|-------------|
 | Framework (`credit_fm`) | `src/credit_fm/` | KVT tokenizer, three-branch model, data layer, training, utils |


### PR DESCRIPTION
## Summary

- add the existing Deeploans OS components SVG to the **What's in here** section
- place it immediately before the component table
- use a repository-relative image path so it works across branches and forks