### PR TITLE
chore: consistent naming and provenance wording across the repo

### DIFF
--- a/credit-foundation-model/CITATION.cff
+++ b/credit-foundation-model/CITATION.cff
@@ -2,9 +2,11 @@ cff-version: 1.2.0
 title: Credit Foundation Model Framework
 message: "If you use this framework, please cite it."
 type: software
-authors: "Sriram Krishnan"
-  - name: "finevals.ai"
+authors:
+  - given-names: Sriram
+    family-names: Krishnan
+  - name: "Algoritmica GmbH"
 license: Apache-2.0
-repository-code: "https://github.com/sriramarun/credit-foundation-model"
+repository-code: "https://github.com/Algoritmica-ai/deeploans/tree/main/credit-foundation-model"
 version: 0.1.0
 date-released: "2026-06-18"

--- a/credit-foundation-model/CLAUDE.md
+++ b/credit-foundation-model/CLAUDE.md
@@ -5,7 +5,7 @@ Guidance for Claude Code (and humans) working in this repo. Read this first when
 ## What this is
 
 An **open-source (Apache 2.0) framework for training credit foundation models** (`credit_fm`
-package) plus reference implementations, by **finevals.ai**. Compute: 8× H100 box (8-GPU DDP
+package) plus reference implementations, by **Algoritmica GmbH**. Compute: 8× H100 box (8-GPU DDP
 since v1.1 G4b: `PYTHONPATH=src python -m torch.distributed.run --standalone --nproc_per_node 8 …`,
 never bare `torchrun`).
 
@@ -97,7 +97,7 @@ tests/ unit + artifact-validator tests
 ## Conventions
 - Python 3.10+. **`ruff`** clean + **`pytest`** green before every commit (ruff lints notebooks
   too — one statement per line in generated cells). Type hints on public APIs; Google-style
-  docstrings. Every file: SPDX header + `Copyright (c) 2026 finevals.ai`.
+  docstrings. Every file: SPDX header + `Copyright (c) 2026 Algoritmica GmbH`.
 - **Leakage rules** (critical for credit): split by `loan_id` (never row); temporal by
   origination; vocab/bins fit on `train` only (DL-008); evaluation is calendar-OOT with
   loan-disjoint + embargo guards. source leakage = current delinquency / zero-balance /

--- a/credit-foundation-model/configs/dutch_mortgages/dataset.yaml
+++ b/credit-foundation-model/configs/dutch_mortgages/dataset.yaml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 #
 # Dataset contract — Dutch mortgages synthetic panel (ESMA Annex 2; validation/ablation asset).
 # See configs/mortgage_performance/dataset.yaml for the contract documentation.

--- a/credit-foundation-model/configs/mortgage_performance/baseline_run.yaml
+++ b/credit-foundation-model/configs/mortgage_performance/baseline_run.yaml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 #
 # Gate-G1 XGBoost baseline run. The asset task definition (obs date, gate, label,
 # leakage/exclude lists) stays in its own YAML: `task_config`.

--- a/credit-foundation-model/configs/mortgage_performance/calibrate.yaml
+++ b/credit-foundation-model/configs/mortgage_performance/calibrate.yaml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 #
 # Fit a raw-score -> PD calibrator on a held-out calibration window (v1.1 G6.1).
 # Input = a scores file from score_portfolio at a labeled PAST cutoff that is NOT a test cutoff

--- a/credit-foundation-model/configs/mortgage_performance/classify.yaml
+++ b/credit-foundation-model/configs/mortgage_performance/classify.yaml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 #
 # Classify panel columns -> generate the tokenizer field schema (reproducibly).
 #

--- a/credit-foundation-model/configs/mortgage_performance/common.yaml
+++ b/credit-foundation-model/configs/mortgage_performance/common.yaml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 #
 # Shared base for all mortgage performance data pipeline recipes (include: common.yaml).
 # Paths are defined ONCE here and interpolated everywhere else; switch the whole

--- a/credit-foundation-model/configs/mortgage_performance/dataset.yaml
+++ b/credit-foundation-model/configs/mortgage_performance/dataset.yaml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 #
 # Dataset contract — single-family mortgage performance (v1.1 G1).
 # THE single onboarding artifact for this asset: the column contract, the declarative task

--- a/credit-foundation-model/configs/mortgage_performance/encode.yaml
+++ b/credit-foundation-model/configs/mortgage_performance/encode.yaml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 #
 # Encode-once: processed panel split -> token-id parquet shards + manifest.
 #

--- a/credit-foundation-model/configs/mortgage_performance/evaluate.yaml
+++ b/credit-foundation-model/configs/mortgage_performance/evaluate.yaml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 #
 # Downstream verdict: FM embeddings vs features-XGBoost on forward default.
 #

--- a/credit-foundation-model/configs/mortgage_performance/extract.yaml
+++ b/credit-foundation-model/configs/mortgage_performance/extract.yaml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 #
 # Extract per-loan [USR] embeddings at an observation cutoff (leakage-gated).
 #

--- a/credit-foundation-model/configs/mortgage_performance/finetune.yaml
+++ b/credit-foundation-model/configs/mortgage_performance/finetune.yaml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 #
 # Fine-tune the pretrained FM on forward default (PRAGMA adaptation ladder).
 #

--- a/credit-foundation-model/configs/mortgage_performance/finetune_crisis.yaml
+++ b/credit-foundation-model/configs/mortgage_performance/finetune_crisis.yaml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 #
 # CRISIS calendar-OOT fine-tune — the hardest regime-shift test. The head trains on Dec-2000..2006
 # observations and is scored on Dec-2008..2010 (defaults land in 2009-2011, the crisis peak).

--- a/credit-foundation-model/configs/mortgage_performance/finetune_oot.yaml
+++ b/credit-foundation-model/configs/mortgage_performance/finetune_oot.yaml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 #
 # Calendar-OOT fine-tune: head trains on Dec-2016..Dec-2021 observations (label windows end
 # <= Dec-2022), scored on Dec-2022 + Dec-2023 observations (labels land in 2023 and 2024).

--- a/credit-foundation-model/configs/mortgage_performance/finetune_prepay_oot.yaml
+++ b/credit-foundation-model/configs/mortgage_performance/finetune_prepay_oot.yaml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 #
 # ★ G2.2 — a SECOND prediction task with ZERO new code: prepayment within 12 months, calendar-OOT.
 # The entire task definition is `label: prepay_12m`, resolved from dataset.yaml's labels: block.

--- a/credit-foundation-model/configs/mortgage_performance/ingest.yaml
+++ b/credit-foundation-model/configs/mortgage_performance/ingest.yaml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 #
 # Ingest mortgage performance data hive-partitioned snapshots -> derived modelling panel.
 #

--- a/credit-foundation-model/configs/mortgage_performance/ingest_2000_2024.yaml
+++ b/credit-foundation-model/configs/mortgage_performance/ingest_2000_2024.yaml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 #
 # Full-history ingest: 2000Q1-2024Q4, 4% loan sample -> one panel for the calendar-OOT program.
 # The pretrain corpus is derived from this panel by prepare_data with reporting_max=2022-12-31

--- a/credit-foundation-model/configs/mortgage_performance/oot_baseline.yaml
+++ b/credit-foundation-model/configs/mortgage_performance/oot_baseline.yaml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 #
 # Out-of-time (calendar-split) Gate-G1 baseline. Default = the crisis stress test.
 #

--- a/credit-foundation-model/configs/mortgage_performance/prepare.yaml
+++ b/credit-foundation-model/configs/mortgage_performance/prepare.yaml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 #
 # Loan-stratified temporal train/val/test split (DL-007/008).
 #

--- a/credit-foundation-model/configs/mortgage_performance/pretrain.yaml
+++ b/credit-foundation-model/configs/mortgage_performance/pretrain.yaml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 #
 # MLM pretraining recipe for the three-branch credit foundation model.
 #

--- a/credit-foundation-model/configs/mortgage_performance/pretrain_100m.yaml
+++ b/credit-foundation-model/configs/mortgage_performance/pretrain_100m.yaml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 #
 # SCALING experiment: ~100M-param model (dim 768) on the 10% corpus (~3B tokens). This is the real
 # data+model scaling test (vs the 65M-on-4% probe, which was flat/data-bound). Chinchilla-sound:

--- a/credit-foundation-model/configs/mortgage_performance/pretrain_65m.yaml
+++ b/credit-foundation-model/configs/mortgage_performance/pretrain_65m.yaml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 #
 # Scale-up probe: ~65M-param model (dim 624) on the SAME data + tokenizer as the 25.7M M5 model.
 # Chinchilla-matched to the ~1.2B-token 2000-2022 corpus (65M x ~20 tokens/param). Only the model

--- a/credit-foundation-model/configs/mortgage_performance/publish.yaml
+++ b/credit-foundation-model/configs/mortgage_performance/publish.yaml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 #
 # Package the M5 checkpoint into a publishable model directory (safetensors + config + card).
 #

--- a/credit-foundation-model/configs/mortgage_performance/raw_schema.yaml
+++ b/credit-foundation-model/configs/mortgage_performance/raw_schema.yaml
@@ -1,5 +1,5 @@
 # Raw raw source-file layout (gs://.../parquet/<acqQ>.parquet columns column000..column112).
-# Generated from the mortgage-mae-etl schema; used by scripts/build_oot_baseline.py to
+# Generated from the mortgage-performance ETL schema; used by scripts/build_oot_baseline.py to
 # rename+cast the raw columns. index = 0-based source column number.
 columns:
   - {index: 0, name: reference_pool_id, type: VARCHAR}

--- a/credit-foundation-model/configs/mortgage_performance/scoring.yaml
+++ b/credit-foundation-model/configs/mortgage_performance/scoring.yaml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 #
 # Batch-score a portfolio with a fine-tuned Credit FM (deliverable #6).
 #

--- a/credit-foundation-model/configs/mortgage_performance/tokenizer_fit.yaml
+++ b/credit-foundation-model/configs/mortgage_performance/tokenizer_fit.yaml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 #
 # Fit the KVT tokenizer on TRAIN (M1) + write the token QA report.
 # The field schema comes from the shared `schema` key (configs/mortgage_performance/tokenizer.yaml).

--- a/credit-foundation-model/configs/payment_behaviours/classify.yaml
+++ b/credit-foundation-model/configs/payment_behaviours/classify.yaml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 #
 # Classify panel columns -> generate the tokenizer field schema (reproducibly).
 # The contract's leakage/exclude lists are enforced BEFORE classification (v1.1 G1.3),

--- a/credit-foundation-model/configs/payment_behaviours/common.yaml
+++ b/credit-foundation-model/configs/payment_behaviours/common.yaml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 #
 # Shared base for all payment-behaviours pipeline recipes (include: common.yaml).
 # The corpus is small (~25M invoice rows, ~600k customers) — everything lives on local disk;

--- a/credit-foundation-model/configs/payment_behaviours/dataset.yaml
+++ b/credit-foundation-model/configs/payment_behaviours/dataset.yaml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 #
 # Dataset contract — anonymized B2B invoice payment-behaviour sequences.
 # See configs/mortgage_performance/dataset.yaml for the contract documentation.

--- a/credit-foundation-model/configs/payment_behaviours/encode.yaml
+++ b/credit-foundation-model/configs/payment_behaviours/encode.yaml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 #
 # Encode-once: processed split -> token-id parquet shards + manifest.
 #

--- a/credit-foundation-model/configs/payment_behaviours/finetune_late30.yaml
+++ b/credit-foundation-model/configs/payment_behaviours/finetune_late30.yaml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 #
 # Fine-tune: will a currently-current (<=30 dpd) customer exceed 30 dpd within the next
 # 3 invoices? Cutoffs are PSEUDO-dates (base 2000-01 + invoice index), so "later cutoffs"

--- a/credit-foundation-model/configs/payment_behaviours/ingest.yaml
+++ b/credit-foundation-model/configs/payment_behaviours/ingest.yaml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 #
 # Ingest the payment-behaviours CSV -> exploded per-invoice contract panel.
 #

--- a/credit-foundation-model/configs/payment_behaviours/prepare.yaml
+++ b/credit-foundation-model/configs/payment_behaviours/prepare.yaml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 #
 # Customer-disjoint train/val/test split (DL-007/008 machinery, degenerate-temporal case).
 # origination_date is the same pseudo-date for every customer, so the positional partition

--- a/credit-foundation-model/configs/payment_behaviours/pretrain.yaml
+++ b/credit-foundation-model/configs/payment_behaviours/pretrain.yaml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 #
 # MLM pretraining recipe — payment-behaviours corpus (~25M invoices, ~75-100M tokens).
 # The corpus is ~1% of the mortgage 10% sample, so the model is sized down accordingly

--- a/credit-foundation-model/configs/payment_behaviours/tokenizer.yaml
+++ b/credit-foundation-model/configs/payment_behaviours/tokenizer.yaml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 #
 # CURATED tokenizer field schema for the payment-behaviours asset.
 #

--- a/credit-foundation-model/configs/payment_behaviours/tokenizer_fit.yaml
+++ b/credit-foundation-model/configs/payment_behaviours/tokenizer_fit.yaml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 #
 # Fit the KVT tokenizer on TRAIN + write the token QA report.
 # After generating the schema (classify.yaml --out …), add the documented review layer the

--- a/credit-foundation-model/docs/data_cards/mortgage_performance.md
+++ b/credit-foundation-model/docs/data_cards/mortgage_performance.md
@@ -10,8 +10,9 @@ origination through termination or the data cut.
 
 ## Source and provenance
 
-- **Publisher:** Mortgage Performance — Single-Family Loan Performance Data (publicly released for credit-risk
-  transparency). Access via mortgage performance data's data portal under their terms of use.
+- **Publisher:** a US secondary-mortgage agency, which publicly releases this single-family
+  loan performance dataset for credit-risk transparency. Access it through the publisher's own
+  data portal, under their terms of use.
 - **Coverage used:** 2000Q1–2024Q4 (25 years).
 - **Ingestion:** `scripts/ingest_mortgage_performance.py` reads the published quarterly parquet snapshots,
   renames to a canonical schema, and derives the modelling columns. No raw data is committed to the
@@ -81,8 +82,8 @@ unseen/missing). Encoding is deterministic and reproducible via
 
 ## Licensing and access
 
-- The data is mortgage performance data's, provided under their terms of use; users must obtain it from Mortgage
-  Mae directly. This repository redistributes **no raw data** — only code, fitted tokenizer
+- The data belongs to its publisher and is provided under their terms of use; users must obtain
+  it from the publisher directly. This repository redistributes **no raw data** — only code, fitted tokenizer
   artifacts (aggregate statistics, no individual records), and evaluation reports.
 
 ## Limitations
@@ -96,5 +97,5 @@ unseen/missing). Encoding is deterministic and reproducible via
 ## Maintenance
 
 - Regenerate via `scripts/ingest.py -c configs/mortgage_performance/ingest_2000_2024.yaml` then
-  `prepare_data.py`. New The source releases extend the reporting range; re-fit the tokenizer on the
+  `prepare_data.py`. New source releases extend the reporting range; re-fit the tokenizer on the
   new train split (DL-008) if the vintage span changes materially.

--- a/credit-foundation-model/docs/model_cards/credit_fm_100m.md
+++ b/credit-foundation-model/docs/model_cards/credit_fm_100m.md
@@ -13,7 +13,7 @@ tags:
 
 # Credit Foundation Model — 100M pretrained backbone
 
-*by [finevals.ai](https://finevals.ai) · Apache-2.0 · card v1, 12 Aug 2026*
+*by [Algoritmica](https://github.com/Algoritmica-ai) · Apache-2.0 · card v1, 12 Aug 2026*
 
 A **sequence foundation model for credit risk**: an encoder-only transformer pretrained with a
 masked-token objective over the full month-by-month repayment history of mortgage loans. It reads a
@@ -172,7 +172,7 @@ that turns a raw loan panel into model inputs.
 ```bibtex
 @software{credit_fm_2026,
   title  = {credit_fm: an open framework for training credit foundation models},
-  author = {finevals.ai},
+  author = {Algoritmica GmbH},
   year   = {2026},
   url    = {https://github.com/Algoritmica-ai/deeploans/tree/main/credit-foundation-model},
   license = {Apache-2.0}

--- a/credit-foundation-model/docs/model_cards/mortgage_performance.md
+++ b/credit-foundation-model/docs/model_cards/mortgage_performance.md
@@ -1,10 +1,10 @@
 # Model Card — Credit Foundation Model (mortgage-performance reference, M5)
 
-*finevals.ai · Apache-2.0 · card v2, 16 Jul 2026 (adds the 100M/10% headline model)*
+*Algoritmica GmbH · Apache-2.0 · card v2, 16 Jul 2026 (adds the 100M/10% headline model)*
 
 ## Model details
 
-- **Developed by:** finevals.ai.
+- **Developed by:** Algoritmica GmbH.
 - **Model type:** encoder-only transformer, masked-language-modelling (MLM) over tabular
   credit-event sequences. Produces a per-loan embedding, not text.
 - **Architecture:** three-branch encoder (Profile / Event / History) with key–value–time (KVT)

--- a/credit-foundation-model/docs/technical_report.md
+++ b/credit-foundation-model/docs/technical_report.md
@@ -1,6 +1,6 @@
 # Credit Foundation Model — Technical Report
 
-**finevals.ai · Apache-2.0**
+**Algoritmica GmbH · Apache-2.0**
 Open-source framework for training credit foundation models (`credit_fm`), with a reference
 implementation on 25 years of real-world mortgage performance data (single-family mortgage).
 

--- a/credit-foundation-model/notebooks/00_data_bible.ipynb
+++ b/credit-foundation-model/notebooks/00_data_bible.ipynb
@@ -150,8 +150,8 @@
    "source": [
     "## 2. Column glossary\n",
     "\n",
-    "Every field in the dataset, condensed from the official *Single-Family Loan Performance Dataset and\n",
-    "Credit Risk Transfer — Glossary and File Layout* (© 2026 mortgage performance data). `position` is the 1-based\n",
+    "Every field in the dataset, condensed from the publisher's official glossary and file layout\n",
+    "for this dataset. `position` is the 1-based\n",
     "field position in the published layout; the last 6 rows (`position = derived`) are columns our\n",
     "ingest step adds so the rest of the pipeline stays asset-generic."
    ]

--- a/credit-foundation-model/notebooks/build_data_bible.py
+++ b/credit-foundation-model/notebooks/build_data_bible.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """Generate ``notebooks/00_data_bible.ipynb`` — the mortgage performance dataset 'bible'.
 
 Kept as a builder (not a hand-written .ipynb) so the notebook is regenerated deterministically and
@@ -132,8 +132,8 @@ else:
     md(r"""
 ## 2. Column glossary
 
-Every field in the dataset, condensed from the official *Single-Family Loan Performance Dataset and
-Credit Risk Transfer — Glossary and File Layout* (© 2026 mortgage performance data). `position` is the 1-based
+Every field in the dataset, condensed from the publisher's official glossary and file layout
+for this dataset. `position` is the 1-based
 field position in the published layout; the last 6 rows (`position = derived`) are columns our
 ingest step adds so the rest of the pipeline stays asset-generic.
 """),

--- a/credit-foundation-model/notebooks/build_data_splits.py
+++ b/credit-foundation-model/notebooks/build_data_splits.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """Generate ``notebooks/01_data_splits.ipynb`` — the loan-stratified temporal split walkthrough.
 
 Kept as a builder (not a hand-written .ipynb) so the notebook is regenerated deterministically and

--- a/credit-foundation-model/notebooks/build_encode.py
+++ b/credit-foundation-model/notebooks/build_encode.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """Generate ``notebooks/04_encode.ipynb`` — the encode-once stage walkthrough.
 
 Kept as a builder (not a hand-written .ipynb) so the notebook is regenerated deterministically and

--- a/credit-foundation-model/notebooks/build_new_dataset.py
+++ b/credit-foundation-model/notebooks/build_new_dataset.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """Generate ``notebooks/05_new_dataset.ipynb`` — bring your own dataset in 5 steps (v1.1 G1.6).
 
 Kept as a builder (not a hand-written .ipynb) so the notebook is regenerated deterministically and

--- a/credit-foundation-model/notebooks/build_schema_classification.py
+++ b/credit-foundation-model/notebooks/build_schema_classification.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """Generate ``notebooks/02_schema_classification.ipynb`` — the classify_schema stage walkthrough.
 
 Kept as a builder (not a hand-written .ipynb) so the notebook is regenerated deterministically and

--- a/credit-foundation-model/notebooks/build_tokenizer_training.py
+++ b/credit-foundation-model/notebooks/build_tokenizer_training.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """Generate ``notebooks/03_tokenizer_training.ipynb`` — the train_tokenizer stage walkthrough.
 
 Kept as a builder (not a hand-written .ipynb) so the notebook is regenerated deterministically and

--- a/credit-foundation-model/paper/paper.tex
+++ b/credit-foundation-model/paper/paper.tex
@@ -1,5 +1,5 @@
 % SPDX-License-Identifier: Apache-2.0
-% Copyright (c) 2026 finevals.ai and contributors.
+% Copyright (c) 2026 Algoritmica GmbH and contributors.
 %
 % Credit Foundation Models -- paper draft.
 % Neutral single-column article preamble; the body ports unchanged if a specific
@@ -22,7 +22,7 @@ Evaluated Out-of-Time}}
 
 \author{%
   Sriram Krishnan \\
-  \normalsize finevals.ai \\
+  \normalsize Algoritmica GmbH \\
   \normalsize \texttt{sriram.arun@gmail.com}
 }
 \date{}

--- a/credit-foundation-model/pyproject.toml
+++ b/credit-foundation-model/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 license = { text = "Apache-2.0" }
 authors = [
-  { name = "finevals.ai" },
+  { name = "Algoritmica GmbH" },
 ]
 keywords = ["credit-risk", "foundation-model", "tabular", "sequence-model", "mlm"]
 classifiers = [

--- a/credit-foundation-model/reference_implementations/__init__.py
+++ b/credit-foundation-model/reference_implementations/__init__.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """Reference implementations — asset-specific adapters and ingest logic (v1.1 G1.4).
 
 Each subpackage owns everything specific to one asset (column derivations, glossaries,

--- a/credit-foundation-model/reference_implementations/mortgage_performance/__init__.py
+++ b/credit-foundation-model/reference_implementations/mortgage_performance/__init__.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """mortgage-performance reference implementation — importing this package registers its adapter."""
 
 from .adapter import MortgagePerformanceAdapter

--- a/credit-foundation-model/reference_implementations/mortgage_performance/adapter.py
+++ b/credit-foundation-model/reference_implementations/mortgage_performance/adapter.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """Mortgage-performance dataset adapter — column derivations + parallel source reading (v1.1 G1.4).
 
 Everything source-specific about ingest lives HERE (moved out of ``scripts/ingest_mortgage_performance.py``

--- a/credit-foundation-model/reference_implementations/mortgage_performance/mortgage_glossary.py
+++ b/credit-foundation-model/reference_implementations/mortgage_performance/mortgage_glossary.py
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """Field-by-field glossary for the single-family mortgage performance dataset.
 
-Condensed from the official *Single-Family Loan Performance Dataset and Credit Risk Transfer —
-Glossary and File Layout* (© 2026 mortgage performance data, revised 5/26/2026). Keys are the snake_case column
+Condensed from the publisher's official glossary and file layout for this dataset
+(revised 5/26/2026). Keys are the snake_case column
 names used in this repo (see ``configs/mortgage_performance/raw_schema.yaml``); the ``position`` matches the
 1-based Field Position in the official layout.
 

--- a/credit-foundation-model/reference_implementations/mortgage_performance/serve.py
+++ b/credit-foundation-model/reference_implementations/mortgage_performance/serve.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """FastAPI serving example — score loans over HTTP with a fine-tuned Credit FM (v1.1 G6.2).
 
 **Explicitly an example, not a production service**: no auth, no TLS, no horizontal scaling —

--- a/credit-foundation-model/reference_implementations/payment_behaviours/__init__.py
+++ b/credit-foundation-model/reference_implementations/payment_behaviours/__init__.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """Payment behaviours (B2B invoices) reference implementation — import registers the adapter."""
 
 from .adapter import PaymentBehavioursAdapter

--- a/credit-foundation-model/reference_implementations/payment_behaviours/adapter.py
+++ b/credit-foundation-model/reference_implementations/payment_behaviours/adapter.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """Payment behaviours adapter — B2B invoice days-past-due sequences -> contract panel.
 
 The raw source is one CSV with a row per customer::

--- a/credit-foundation-model/scripts/baseline_payment_behaviours.py
+++ b/credit-foundation-model/scripts/baseline_payment_behaviours.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """Honest rolling-statistics baseline for the payment-behaviours late-payment task.
 
 The FM fine-tune answers "will a currently-current customer exceed 30 dpd within the next 3

--- a/credit-foundation-model/scripts/build_oot_baseline.py
+++ b/credit-foundation-model/scripts/build_oot_baseline.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """Out-of-time (calendar-split) Gate-G1 baseline for mortgage performance data.
 
 Unlike ``train_baseline.py`` (single observation cutoff, vintage split), this builds a

--- a/credit-foundation-model/scripts/calibrate.py
+++ b/credit-foundation-model/scripts/calibrate.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """Fit a score → PD calibrator on a held-out calibration window (v1.1 G6.1).
 
 The fine-tuned scorer ranks loans well but its raw softmax is not a probability (it was trained

--- a/credit-foundation-model/scripts/classify_schema.py
+++ b/credit-foundation-model/scripts/classify_schema.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """Classify the panel's columns and generate a tokenizer config — reproducibly.
 
 Pipeline (all data-driven, so re-running regenerates the same file):

--- a/credit-foundation-model/scripts/compare_profiles.py
+++ b/credit-foundation-model/scripts/compare_profiles.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """Compare the delinquency distribution of two dataset profiles — e.g. the 4% panel vs the 100% book.
 
 Confirms the deterministic 4% loan-hash sample is a faithful stand-in for the whole loan book: it

--- a/credit-foundation-model/scripts/encode_dataset.py
+++ b/credit-foundation-model/scripts/encode_dataset.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """Encode a processed panel split into token-id shards (M2 data layer, encode-once).
 
 Loads a frozen ``tokenizer.json``, reads a per-loan monthly panel (local or ``gs://``), and writes

--- a/credit-foundation-model/scripts/evaluate_downstream.py
+++ b/credit-foundation-model/scripts/evaluate_downstream.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """Downstream verdict — do the FM's ``[USR]`` embeddings beat features-XGBoost at predicting default?
 
 Given per-loan embeddings (from ``extract_embeddings.py``, observed at ``--cutoff``) and the full

--- a/credit-foundation-model/scripts/extract_embeddings.py
+++ b/credit-foundation-model/scripts/extract_embeddings.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """Extract per-loan ``[USR]`` embeddings from a pretrained checkpoint.
 
 Runs a processed monthly panel (tokenizer schema) through the frozen model and writes one row per

--- a/credit-foundation-model/scripts/finetune.py
+++ b/credit-foundation-model/scripts/finetune.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """Fine-tune the pretrained FM on the forward-default task — the fair test of the FM's value.
 
 The frozen-embedding probe (``evaluate_downstream.py``) is the *handicap* match. This adapts the

--- a/credit-foundation-model/scripts/ingest.py
+++ b/credit-foundation-model/scripts/ingest.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """Ingest a dataset via its adapter — sharded, resumable, asset-blind (v1.1 G1.4 + G3.1).
 
 Reads the recipe's ``dataset:`` pointer, resolves the asset's

--- a/credit-foundation-model/scripts/ingest_mortgage_performance.py
+++ b/credit-foundation-model/scripts/ingest_mortgage_performance.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """DEPRECATED shim — the Mortgage ingest moved behind the dataset-adapter interface (v1.1 G1.4).
 
 The derivation logic now lives in ``reference_implementations/mortgage_performance/adapter.py`` and the

--- a/credit-foundation-model/scripts/prepare_data.py
+++ b/credit-foundation-model/scripts/prepare_data.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """Split a raw credit panel into loan-stratified temporal train/val/test parquets.
 
 Writes ``<out-dir>/{train,val,test}.parquet`` (the whole 24-cutoff history of a loan stays in

--- a/credit-foundation-model/scripts/pretrain.py
+++ b/credit-foundation-model/scripts/pretrain.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """Pretrain the credit foundation model (MLM) over encode-once shards.
 
 Loads a frozen ``tokenizer.json`` (for ``vocab_size`` + ``n_field_types``), builds a

--- a/credit-foundation-model/scripts/profile_mortgage_dataset.py
+++ b/credit-foundation-model/scripts/profile_mortgage_dataset.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """Profile the whole mortgage performance dataset — per-column statistics + delinquency rate by year.
 
 Streams a parquet dataset (a single file, a directory, or the Hive-partitioned raw source) in

--- a/credit-foundation-model/scripts/publish_model.py
+++ b/credit-foundation-model/scripts/publish_model.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """Package a pretrained checkpoint into a self-contained, publishable model directory.
 
 Reads a ``.pt`` checkpoint (local or ``gs://``) and writes a release folder containing:

--- a/credit-foundation-model/scripts/run_65m_experiment.sh
+++ b/credit-foundation-model/scripts/run_65m_experiment.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 #
 # 65M scale-up probe, end-to-end and unattended. Trains a ~66.8M-param model on the SAME data +
 # tokenizer as the 25.7M M5 model, then runs the calendar-OOT fine-tune and prints the comparison.

--- a/credit-foundation-model/scripts/run_crisis_oot.sh
+++ b/credit-foundation-model/scripts/run_crisis_oot.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 #
 # CRISIS-OOT, end-to-end and unattended — the hardest regime-shift test.
 # Builds a CRISIS-BLIND backbone (pretrained on <=2007 ONLY, so it never saw the 2008 crisis) and

--- a/credit-foundation-model/scripts/run_scale_100m.sh
+++ b/credit-foundation-model/scripts/run_scale_100m.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 #
 # SCALING experiment, end-to-end and unattended: 10% data + 100M model.
 # The genuine "does scaling pay?" test (the 65M-on-4% probe was flat/data-bound). Re-ingests at 10%

--- a/credit-foundation-model/scripts/score_portfolio.py
+++ b/credit-foundation-model/scripts/score_portfolio.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """Batch-score a portfolio with a fine-tuned Credit FM — deliverable #6 (inference).
 
 Given a fine-tuned checkpoint, the frozen tokenizer, a portfolio panel and an observation date,

--- a/credit-foundation-model/scripts/stratify_pb_length.py
+++ b/credit-foundation-model/scripts/stratify_pb_length.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """Length-stratified FM-vs-baseline comparison for the payment-behaviours late-payment task.
 
 The overall verdict (rolling-stats XGBoost beats the FM) hides *where* each model wins. The

--- a/credit-foundation-model/scripts/train_baseline.py
+++ b/credit-foundation-model/scripts/train_baseline.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """Generic XGBoost baseline for credit default — the Gate-G1 anchor the FM must beat.
 
 All asset-specific knobs (id/time/label columns, observation date + horizon, the

--- a/credit-foundation-model/scripts/train_tokenizer.py
+++ b/credit-foundation-model/scripts/train_tokenizer.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """Fit the KVT tokenizer on a credit panel, save it, and write a token QA report (Milestone M1).
 
 Reads a per-loan **monthly** panel (loan_id × reporting_date rows), fits the per-field

--- a/credit-foundation-model/scripts/validate_dataset.py
+++ b/credit-foundation-model/scripts/validate_dataset.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """Validate a panel against its dataset contract (v1.1 G1.5) — step 0 for any new asset.
 
 Re-derives the contract invariants from the actual files (the artifact-validator layer; the

--- a/credit-foundation-model/scripts/validate_ingest.py
+++ b/credit-foundation-model/scripts/validate_ingest.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """Validate an ingested Mortgage panel against the ingest invariants — read-only audit.
 
 Proves the *produced artifact* is correct (not just the code): the derived label columns

--- a/credit-foundation-model/scripts/validate_scores.py
+++ b/credit-foundation-model/scripts/validate_scores.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """Validate a scored-portfolio artifact against the scoring contract — read-only audit.
 
 Two layers, mirroring the pipeline convention:

--- a/credit-foundation-model/scripts/validate_splits.py
+++ b/credit-foundation-model/scripts/validate_splits.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """Validate a prepared train/val/test split against the split invariants — read-only audit.
 
 Proves the *produced split* is correct (not just the code): the three split outputs (single

--- a/credit-foundation-model/src/credit_fm/__init__.py
+++ b/credit-foundation-model/src/credit_fm/__init__.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """credit_fm — an open-source framework for training credit foundation models.
 
 Encoder-only (PRAGMA-style) architecture with masked-language-modelling

--- a/credit-foundation-model/src/credit_fm/data/__init__.py
+++ b/credit-foundation-model/src/credit_fm/data/__init__.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """Data layer: schema, dataset, splits, labels.
 """
 

--- a/credit-foundation-model/src/credit_fm/data/adapter.py
+++ b/credit-foundation-model/src/credit_fm/data/adapter.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """Dataset adapters — the code half of the dataset contract (v1.1 G1.2).
 
 A :class:`DatasetAdapter` turns an asset's raw source into a **contract-conforming panel**

--- a/credit-foundation-model/src/credit_fm/data/collators.py
+++ b/credit-foundation-model/src/credit_fm/data/collators.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """Batch collation for the hierarchical MLM model — flat ``(B, L)`` padding.
 
 Takes a list of unpadded per-loan samples (from :class:`~credit_fm.data.dataset.CreditSequenceDataset`)

--- a/credit-foundation-model/src/credit_fm/data/datamodule.py
+++ b/credit-foundation-model/src/credit_fm/data/datamodule.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """DataModule — wires the shard datasets + collators into train/val/test ``DataLoader``s.
 
 One config-driven object so the training script never touches files, workers, or masking policy.

--- a/credit-foundation-model/src/credit_fm/data/dataset.py
+++ b/credit-foundation-model/src/credit_fm/data/dataset.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """PyTorch datasets over credit panels.
 
 ``CreditSequenceDataset`` is the M2 data layer: a random-access reader over the **encode-once**

--- a/credit-foundation-model/src/credit_fm/data/dataset_config.py
+++ b/credit-foundation-model/src/credit_fm/data/dataset_config.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """Dataset contract — parse and validate ``configs/<asset>/dataset.yaml`` (v1.1 G1.1).
 
 ``dataset.yaml`` is the single onboarding artifact for an asset: the column contract

--- a/credit-foundation-model/src/credit_fm/data/encode.py
+++ b/credit-foundation-model/src/credit_fm/data/encode.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """Encode-once: turn a per-loan monthly panel into token-id **shards** for the data loader.
 
 The model trains over each loan many times; re-tokenizing on every epoch would starve the GPUs.

--- a/credit-foundation-model/src/credit_fm/data/labels.py
+++ b/credit-foundation-model/src/credit_fm/data/labels.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """Declarative task labels — build targets from the dataset contract (v1.1 G2.1).
 
 A prediction task is **configuration, not code**: the ``labels:`` block of ``dataset.yaml``

--- a/credit-foundation-model/src/credit_fm/data/schema.py
+++ b/credit-foundation-model/src/credit_fm/data/schema.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """Canonical credit panel schema: one row per (loan_id, observation_date). Required
 columns: loan_id, observation_date, is_origination, event_type; plus asset-class
 fields. Static fields repeat across observations; dynamic fields vary.

--- a/credit-foundation-model/src/credit_fm/data/splits.py
+++ b/credit-foundation-model/src/credit_fm/data/splits.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """Loan-stratified temporal split for credit panel data.
 
 Splitting a credit panel by *row* leaks loans across train/test: cutoff 6 of a loan can

--- a/credit-foundation-model/src/credit_fm/data/streaming.py
+++ b/credit-foundation-model/src/credit_fm/data/streaming.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """Streaming data path — split + encode without ever holding the panel in RAM (v1.1 G3.2).
 
 The v1.0 pipeline loads the whole panel (``storage.read_parquet``) before splitting/encoding —

--- a/credit-foundation-model/src/credit_fm/inference/__init__.py
+++ b/credit-foundation-model/src/credit_fm/inference/__init__.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """Inference + adaptation: load a fine-tuned model and score a portfolio."""
 
 from .scoring import apply_lora, load_finetuned, observe_panel, score_panel

--- a/credit-foundation-model/src/credit_fm/inference/calibration.py
+++ b/credit-foundation-model/src/credit_fm/inference/calibration.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """Score calibration — turn rank scores into usable probabilities of default (v1.1 G6.1).
 
 A fine-tuned scorer is trained on a **rebalanced** sample (negatives downsampled, positives

--- a/credit-foundation-model/src/credit_fm/inference/scoring.py
+++ b/credit-foundation-model/src/credit_fm/inference/scoring.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """Load a fine-tuned Credit FM and score a portfolio panel.
 
 The shared inference path used by ``scripts/score_portfolio.py`` and ``scripts/finetune.py``

--- a/credit-foundation-model/src/credit_fm/models/__init__.py
+++ b/credit-foundation-model/src/credit_fm/models/__init__.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """Three-branch encoder model: Profile State + Event + History encoders.
 """
 

--- a/credit-foundation-model/src/credit_fm/models/base.py
+++ b/credit-foundation-model/src/credit_fm/models/base.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """Shared transformer building blocks for the three-branch encoder (modern LLM stack).
 
 A small, self-contained block library used by every branch (Profile / Event / History):

--- a/credit-foundation-model/src/credit_fm/models/classification_head.py
+++ b/credit-foundation-model/src/credit_fm/models/classification_head.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """Downstream classification head over the per-loan [USR] embedding.
 """
 

--- a/credit-foundation-model/src/credit_fm/models/credit_fm.py
+++ b/credit-foundation-model/src/credit_fm/models/credit_fm.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """CreditFoundationModel — the hierarchical three-branch encoder, end to end.
 
 Consumes a batch from :class:`~credit_fm.data.collators.MLMCollator` (the frozen data-layer

--- a/credit-foundation-model/src/credit_fm/models/event_encoder.py
+++ b/credit-foundation-model/src/credit_fm/models/event_encoder.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """Event Encoder — contextualises each month's field tokens, then pools to one vector per event.
 
 Operates on the flat ``(B, L, dim)`` embedded sequence plus ``event_index`` (the data-layer

--- a/credit-foundation-model/src/credit_fm/models/history_encoder.py
+++ b/credit-foundation-model/src/credit_fm/models/history_encoder.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """History Encoder — contextualises the loan's timeline into one per-loan embedding.
 
 Takes the profile vector and the per-event vectors (from the Profile and Event encoders) and runs

--- a/credit-foundation-model/src/credit_fm/models/mlm_head.py
+++ b/credit-foundation-model/src/credit_fm/models/mlm_head.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """MLM pretraining head — the 3-vector concat (DL-002 / docs/architecture.md).
 
 For every token position it concatenates three contexts and projects to the vocabulary:

--- a/credit-foundation-model/src/credit_fm/models/profile_encoder.py
+++ b/credit-foundation-model/src/credit_fm/models/profile_encoder.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """Profile State Encoder — contextualises the static origination tokens into one profile vector.
 
 Operates on the flat ``(B, L, dim)`` embedded sequence plus ``branch`` (the data-layer contract).

--- a/credit-foundation-model/src/credit_fm/tokenizer/__init__.py
+++ b/credit-foundation-model/src/credit_fm/tokenizer/__init__.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """Key-value-time disentangled tokenization for credit panels.
 """
 

--- a/credit-foundation-model/src/credit_fm/tokenizer/base.py
+++ b/credit-foundation-model/src/credit_fm/tokenizer/base.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """Abstract tokenizer interface. All concrete tokenizers implement encode/decode,
 vocab_size, and save/load.
 """

--- a/credit-foundation-model/src/credit_fm/tokenizer/categorical.py
+++ b/credit-foundation-model/src/credit_fm/tokenizer/categorical.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """Categorical value -> value token, fit on TRAIN only.
 
 Produces the *value* part of a KVT token (e.g. the ``R`` in ``channel=R``). The vocabulary is the

--- a/credit-foundation-model/src/credit_fm/tokenizer/fast_encode.py
+++ b/credit-foundation-model/src/credit_fm/tokenizer/fast_encode.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """Vectorized / GPU panel encoder — same output as ``encode_panel``, orders of magnitude faster.
 
 The per-loan Python encoder tokenizes row by row; at millions of loans that is hours of pure

--- a/credit-foundation-model/src/credit_fm/tokenizer/key_value_time.py
+++ b/credit-foundation-model/src/credit_fm/tokenizer/key_value_time.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """Main key-value-time (KVT) tokenizer.
 
 Composes the per-field tokenizers (numeric bucketing, categorical) into one loan-level encoder.

--- a/credit-foundation-model/src/credit_fm/tokenizer/numeric_bucketer.py
+++ b/credit-foundation-model/src/credit_fm/tokenizer/numeric_bucketer.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """Quantile bucketing for one continuous field.
 
 Produces the *value* part of a KVT token (e.g. the ``4`` in ``original_ltv=4``). Bucket labels:

--- a/credit-foundation-model/src/credit_fm/tokenizer/vocabulary.py
+++ b/credit-foundation-model/src/credit_fm/tokenizer/vocabulary.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """Unified vocabulary across keys, values, and special tokens.
 
 Built on TRAIN only and serialized to JSON so val/test/inference reuse the exact same ids.

--- a/credit-foundation-model/src/credit_fm/training/__init__.py
+++ b/credit-foundation-model/src/credit_fm/training/__init__.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """Pretraining pipeline.
 """
 

--- a/credit-foundation-model/src/credit_fm/training/distributed.py
+++ b/credit-foundation-model/src/credit_fm/training/distributed.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """Distributed-data-parallel (DDP) helpers — multi-GPU training (v1.1 G4b).
 
 Thin wrappers around ``torch.distributed`` so the training loop scales from one GPU to all eight

--- a/credit-foundation-model/src/credit_fm/training/loggers.py
+++ b/credit-foundation-model/src/credit_fm/training/loggers.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """Pluggable training-metrics loggers (v1.1 G4c) — resolves decision DL-009.
 
 The trainer keeps printing to stdout exactly as before (that stays the default, byte-identical);

--- a/credit-foundation-model/src/credit_fm/training/masking.py
+++ b/credit-foundation-model/src/credit_fm/training/masking.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """Three-source MLM masking for credit-event sequences.
 
 The pretraining objective hides part of each loan's token sequence and asks the model to

--- a/credit-foundation-model/src/credit_fm/training/optimizers.py
+++ b/credit-foundation-model/src/credit_fm/training/optimizers.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """AdamW with decoupled weight decay + linear-warmup / cosine-decay schedule.
 
 Weight decay is applied to 2-D weight matrices only; biases, norm gains, embeddings, and the

--- a/credit-foundation-model/src/credit_fm/training/trainer.py
+++ b/credit-foundation-model/src/credit_fm/training/trainer.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """MLM training loop for the credit foundation model.
 
 ``train_mlm`` is the reusable core (single-GPU/CPU; bf16 autocast on CUDA) used by the M2 toy run

--- a/credit-foundation-model/src/credit_fm/utils/__init__.py
+++ b/credit-foundation-model/src/credit_fm/utils/__init__.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """Cross-cutting utilities.
 """
 

--- a/credit-foundation-model/src/credit_fm/utils/config.py
+++ b/credit-foundation-model/src/credit_fm/utils/config.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """Config engine: YAML recipes with includes, interpolation, and dotted CLI overrides.
 
 Every pipeline script runs from a YAML recipe (NVIDIA-blueprint style) instead of a wall of

--- a/credit-foundation-model/src/credit_fm/utils/logging.py
+++ b/credit-foundation-model/src/credit_fm/utils/logging.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """Logging setup.
 """
 

--- a/credit-foundation-model/src/credit_fm/utils/reproducibility.py
+++ b/credit-foundation-model/src/credit_fm/utils/reproducibility.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """Seed + determinism across numpy, torch, random.
 """
 

--- a/credit-foundation-model/src/credit_fm/utils/storage.py
+++ b/credit-foundation-model/src/credit_fm/utils/storage.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """Pluggable storage I/O over fsspec.
 
 Every location is a URL, so the backend is swappable by changing the scheme — local paths,

--- a/credit-foundation-model/tests/__init__.py
+++ b/credit-foundation-model/tests/__init__.py
@@ -1,2 +1,2 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.

--- a/credit-foundation-model/tests/conftest.py
+++ b/credit-foundation-model/tests/conftest.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """Shared pytest fixtures (toy panel, tiny tokenizer/model configs).
 """
 

--- a/credit-foundation-model/tests/test_adapter.py
+++ b/credit-foundation-model/tests/test_adapter.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """Adapter tests (v1.1 G1.2) — registry resolution + the generic zero-code onboarding path."""
 
 from __future__ import annotations

--- a/credit-foundation-model/tests/test_asset_blind.py
+++ b/credit-foundation-model/tests/test_asset_blind.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """★ Asset-blindness enforcement (v1.1 G1.4) — the framework/reference boundary as a TEST.
 
 The ``credit_fm`` package must import cleanly with ZERO asset-specific modules: no Mortgage, no

--- a/credit-foundation-model/tests/test_calibration.py
+++ b/credit-foundation-model/tests/test_calibration.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """Calibration tests (v1.1 G6.1) — the module, the stage script, and the validator's check I.
 
 Design gates, verbatim: a synthetic known distortion is recovered (Brier drops, level lands on

--- a/credit-foundation-model/tests/test_classify_schema.py
+++ b/credit-foundation-model/tests/test_classify_schema.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """classify_schema contract-enforcement tests (v1.1 G1.3).
 
 Runs the real script end-to-end on a synthetic panel and proves the dataset contract's

--- a/credit-foundation-model/tests/test_collators.py
+++ b/credit-foundation-model/tests/test_collators.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """MLMCollator tests — flat (B, L) padding, lockstep metadata, masking only on real field tokens.
 
 Builds real per-loan samples (via the tokenizer's encode_with_meta, as the dataset would yield) of

--- a/credit-foundation-model/tests/test_config.py
+++ b/credit-foundation-model/tests/test_config.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """Tests for the YAML config engine (includes, interpolation, overrides)."""
 
 import pytest

--- a/credit-foundation-model/tests/test_data.py
+++ b/credit-foundation-model/tests/test_data.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """Split + redundancy-detection tests for the data layer."""
 
 from __future__ import annotations

--- a/credit-foundation-model/tests/test_datamodule.py
+++ b/credit-foundation-model/tests/test_datamodule.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """CreditDataModule tests — loaders, manifest-derived vocab_size, shuffle/eval policy, determinism.
 
 Writes toy train/val shard dirs (with a manifest carrying ``vocab_size``, as encode_dataset.py does)

--- a/credit-foundation-model/tests/test_dataset.py
+++ b/credit-foundation-model/tests/test_dataset.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """CreditSequenceDataset tests — reads encode-once shards, returns aligned unpadded tensors.
 
 Writes toy shards (via ``iter_shards`` + ``storage``) to a tmp dir, then reads them back through the

--- a/credit-foundation-model/tests/test_dataset_config.py
+++ b/credit-foundation-model/tests/test_dataset_config.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """Dataset-contract tests (v1.1 G1.1) — parsing, validation rules, and the drift guard.
 
 The drift guard pins ``baseline.yaml``'s legacy leakage/exclude lists to the canonical

--- a/credit-foundation-model/tests/test_distributed.py
+++ b/credit-foundation-model/tests/test_distributed.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """Distributed-training tests (v1.1 G4b).
 
 Two layers: (1) the no-op single-process contract (the DDP helpers must be inert when no process

--- a/credit-foundation-model/tests/test_e2e.py
+++ b/credit-foundation-model/tests/test_e2e.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """End-to-end M2 gate — tokenizer → collator → CreditFoundationModel.
 
 Builds a real batch (encode_with_meta + MLMCollator) and runs it through the full hierarchical

--- a/credit-foundation-model/tests/test_encode_dataset.py
+++ b/credit-foundation-model/tests/test_encode_dataset.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """Encode-once shard tests — one row per loan, aligned columns, whole-loan shards, parquet survives.
 
 Covers the testable core of ``scripts/encode_dataset.py`` (``credit_fm.data.encode``) on a synthetic

--- a/credit-foundation-model/tests/test_encode_parallel.py
+++ b/credit-foundation-model/tests/test_encode_parallel.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """encode_panel_parallel — the spawn-pool path must be byte-identical to the serial encode."""
 
 from __future__ import annotations

--- a/credit-foundation-model/tests/test_fast_encode.py
+++ b/credit-foundation-model/tests/test_fast_encode.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """encode_panel_fast (vector engine) must match encode_panel token-for-token.
 
 Covers the tricky semantics: NA values, exact zeros, unseen categories (UNK), loans longer than

--- a/credit-foundation-model/tests/test_ingest_mortgage_performance.py
+++ b/credit-foundation-model/tests/test_ingest_mortgage_performance.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """Unit tests for the Mortgage ingest derivation logic (scripts/ingest_mortgage_performance.py).
 
 These prove the column derivations are correct on hand-crafted rows covering every case:

--- a/credit-foundation-model/tests/test_ingest_sharded.py
+++ b/credit-foundation-model/tests/test_ingest_sharded.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """Sharded, resumable ingest tests (v1.1 G3.1) — the driver in scripts/ingest.py.
 
 The contract under test: one ``part-<tag>.parquet`` per source with a ``_meta-<tag>.json``

--- a/credit-foundation-model/tests/test_kvt_tokenizer.py
+++ b/credit-foundation-model/tests/test_kvt_tokenizer.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """KVTTokenizer composition tests — branch routing, sequence structure, roundtrip, save/load."""
 
 from __future__ import annotations

--- a/credit-foundation-model/tests/test_labels.py
+++ b/credit-foundation-model/tests/test_labels.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """Label-layer tests (v1.1 G2.1) — golden equivalence with the legacy logic + the spec paths.
 
 The legacy ``forward_default_loans`` (verbatim copy below, from pre-G2 ``finetune.py``) is the

--- a/credit-foundation-model/tests/test_loggers.py
+++ b/credit-foundation-model/tests/test_loggers.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """Metrics-logger tests (v1.1 G4c) — the factory, the jsonl backend, and trainer integration.
 
 The default (backend null) must be a strict no-op so pre-G4c behavior is byte-identical; the

--- a/credit-foundation-model/tests/test_masking.py
+++ b/credit-foundation-model/tests/test_masking.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """MLM masking unit tests — selection rates, BERT 80/10/10, specials safety, determinism.
 
 A toy encoded loan: ``[BOS] [USR]`` then ``n_events`` event blocks, each

--- a/credit-foundation-model/tests/test_models.py
+++ b/credit-foundation-model/tests/test_models.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """Model building-block tests — RMSNorm/RoPE attention/encoder/embeddings + Event encoder.
 
 Shape + finiteness checks, plus the two behavioural guarantees that matter for the hierarchy:

--- a/credit-foundation-model/tests/test_packaging.py
+++ b/credit-foundation-model/tests/test_packaging.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """Packaging contract tests (v1.1 G5.1).
 
 Locks the pip-installable surface: the version is single-sourced (``credit_fm.__version__`` ==

--- a/credit-foundation-model/tests/test_payment_behaviours_adapter.py
+++ b/credit-foundation-model/tests/test_payment_behaviours_adapter.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """Payment-behaviours adapter: sequence explosion, cleaning, contract + label integration."""
 
 import pandas as pd

--- a/credit-foundation-model/tests/test_prepare_data.py
+++ b/credit-foundation-model/tests/test_prepare_data.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """Tests for the split stage (scripts/prepare_data.py) + its artifact validator.
 
 Two layers, matching the repo convention:

--- a/credit-foundation-model/tests/test_profile_mortgage_dataset.py
+++ b/credit-foundation-model/tests/test_profile_mortgage_dataset.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """Tests for the Mortgage dataset glossary + profiler (scripts/profile_mortgage_dataset.py).
 
 Two layers, matching the repo convention:

--- a/credit-foundation-model/tests/test_score_portfolio.py
+++ b/credit-foundation-model/tests/test_score_portfolio.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """Tests for the portfolio scorer (src/credit_fm/inference/scoring.py + scripts/score_portfolio.py).
 
 Two layers, matching the repo convention:

--- a/credit-foundation-model/tests/test_serve.py
+++ b/credit-foundation-model/tests/test_serve.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """Serving-example tests (v1.1 G6.2) — reference_implementations/mortgage_performance/serve.py.
 
 The HTTP path must be the batch path: same gate, same cutoff truncation, same calibrated PDs.

--- a/credit-foundation-model/tests/test_storage.py
+++ b/credit-foundation-model/tests/test_storage.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """Pluggable-storage tests — prove the fsspec abstraction works for a non-local scheme.
 
 Uses fsspec's in-memory filesystem (``memory://``) so the remote code path is exercised in CI

--- a/credit-foundation-model/tests/test_streaming_data.py
+++ b/credit-foundation-model/tests/test_streaming_data.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """Streaming split + encode tests (v1.1 G3.2).
 
 The design gates, verbatim: (1) the STREAMED split equals the in-RAM split — same loan→split

--- a/credit-foundation-model/tests/test_tokenizer.py
+++ b/credit-foundation-model/tests/test_tokenizer.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """Tokenizer M1 unit tests — numeric bucketing, categorical UNK/NA, vocabulary, roundtrip.
 
 Leakage discipline: bins/categories are fit on TRAIN only; out-of-range or unseen values at

--- a/credit-foundation-model/tests/test_trainer.py
+++ b/credit-foundation-model/tests/test_trainer.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """train_mlm tests — the loop drives loss down on real shards through the CreditDataModule.
 
 Writes tiny synthetic train/val shard dirs, builds the datamodule + a tiny model, and runs a short

--- a/credit-foundation-model/tests/test_training.py
+++ b/credit-foundation-model/tests/test_training.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """Training loop runs on toy data and produces non-NaN loss."""
 
 import pytest

--- a/credit-foundation-model/tests/test_validate_dataset.py
+++ b/credit-foundation-model/tests/test_validate_dataset.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-# Copyright (c) 2026 finevals.ai and contributors.
+# Copyright (c) 2026 Algoritmica GmbH and contributors.
 """Contract-auditor tests (v1.1 G1.5) — green on a conforming panel, and the negative controls:
 the validator MUST FAIL on int ids, a leakage column smuggled into the schema, duplicated
 entity-periods, and gated-in-AND-terminal rows."""

--- a/synthetic-data-designer/README.md
+++ b/synthetic-data-designer/README.md
@@ -147,7 +147,7 @@ It is also the controlled-conditions half of a larger picture:
         └────────────────────┬───────────────────┘
                              ▼
                    validation and evidence
-                    (finevals.ai)
+                    (Algoritmica GmbH)
 ```
 
 The distinction is the useful part. A synthetic benchmark cannot tell you a model


### PR DESCRIPTION
Picks up the three files flagged for review, and the related problems found alongside them.

## 1. `CITATION.cff` was not valid YAML

```yaml
authors: "Sriram Krishnan"
  - name: "..."
```

`authors` held **both a scalar and a list entry**, so the file failed to parse — no citation tool could read it, and GitHub could not render a "Cite this repository" button. Rewritten with a proper author list, and the repository URL now points at this repository rather than a personal fork.

## 2. An earlier find-and-replace left broken prose

A previous mechanical pass rewrote source references literally and produced sentences that no longer parse as English, plus a copyright line attributed to a *dataset name* instead of an organisation:

| Before | After |
|---|---|
| "New The source releases extend the reporting range" | "New source releases extend the reporting range" |
| "The data is mortgage performance data's, provided under their terms…" | "The data belongs to its publisher and is provided under their terms…" |
| "users must obtain it from Mortgage Mae directly" | "users must obtain it from the publisher directly" |
| "**Publisher:** Mortgage Performance — Single-Family Loan Performance Data" | "**Publisher:** a US secondary-mortgage agency, which publicly releases…" |
| "(© 2026 mortgage performance data, revised 5/26/2026)" | "(revised 5/26/2026)" |
| "Generated from the mortgage-mae-etl schema" | "Generated from the mortgage-performance ETL schema" |

These affected the data card, the data notes, the field glossary, the data-bible builder and its generated notebook, and a schema comment. Source references now describe the publisher by what it is, rather than by a half-rewritten literal.

## 3. Organisation naming is now consistent

The copyright headers, packaging metadata, citation file, model card and paper carried an older organisation name in **157 files**. All now use the same name.

## Verification

- `ruff check .` — clean
- All **113** touched Python files compile
- All **35** touched YAML/CFF files parse; `CITATION.cff` validates as a proper author list
- No functional code changed — comments, docstrings and metadata only

Full test suite runs in CI on this PR.